### PR TITLE
fix(itesco): follow the new /shop/<locale>/browse URL scheme

### DIFF
--- a/actors/itesco-daily/main.js
+++ b/actors/itesco-daily/main.js
@@ -27,8 +27,8 @@ const Labels = {
 
 /** @enum {string} */
 const StartUrls = {
-  CZ: "https://nakup.itesco.cz/groceries/cs-CZ/",
-  SK: "https://potravinydomov.itesco.sk/groceries/sk-SK/"
+  CZ: "https://nakup.itesco.cz/shop/cs-CZ/landing/groceries",
+  SK: "https://potravinydomov.itesco.sk/shop/sk-SK/landing/groceries"
 };
 
 /**
@@ -148,7 +148,7 @@ function extractItems({ document, country, uniqueItems, stats }) {
       currentPrice: typeof price.actual === "number" ? price.actual : cleanPrice(price.actual),
       currentUnitPrice: typeof price.unitPrice === "number" ? price.unitPrice : cleanPrice(price.unitPrice),
       discounted: false,
-      itemUrl: `${rootUrl}/groceries/${locale}/products/${product.id}`
+      itemUrl: `${rootUrl}/shop/${locale}/products/${product.id}`
     };
 
     // Find the first non-Clubcard promotion (matching the old `.offer-text`
@@ -202,14 +202,18 @@ function extractItems({ document, country, uniqueItems, stats }) {
 /**
  * Extract top-level category URLs from the groceries homepage. Replaces the
  * old `.menu__link--superdepartment` DOM class (removed in the ddsweb
- * migration) with an href regex matching `/groceries/<locale>/shop/<slug>/all`
+ * migration) with an href regex matching `/shop/<locale>/browse/<slug>/all`
  * filtered to top-level superdepartments (exactly one slug segment).
+ * The whole URL scheme moved from `/groceries/<locale>/shop/…` to
+ * `/shop/<locale>/browse/…` (old paths only 301-redirect), so the old pattern
+ * matched nothing and the START handler queued zero categories.
  * @param {Document} document
  * @param {Country} country
  */
 function startUrls(document, country) {
   const rootUrl = country === Country.CZ ? "https://nakup.itesco.cz" : "https://potravinydomov.itesco.sk";
-  const pattern = /^(?:https?:\/\/[^/]+)?(\/groceries\/[a-z]{2}-[A-Z]{2}\/shop\/[^/?#]+\/all)(?:[?#]|$)/;
+  const locale = country === Country.CZ ? "cs-CZ" : "sk-SK";
+  const pattern = new RegExp(`^(?:https?://[^/]+)?(/shop/${locale}/browse/[^/?#]+/all)(?:[?#]|$)`);
   const seen = new Set();
   const hrefs = [];
   for (const a of document.querySelectorAll("a[href]")) {
@@ -314,7 +318,7 @@ async function main() {
     type = ActorType.Full,
     // TODO: use urls = []; instead
     bfUrl = "https://itesco.cz/akcni-nabidky/seznam-produktu/black-friday/",
-    testUrl = "https://nakup.itesco.cz/groceries/cs-CZ/shop/pekarna/all"
+    testUrl = "https://nakup.itesco.cz/shop/cs-CZ/browse/pekarna/all"
   } = await getInput();
 
   if (development) {


### PR DESCRIPTION
Closes #3585, closes #2952.

## Problem

Tesco moved its grocery URLs from `/groceries/<locale>/shop/<slug>/all` to `/shop/<locale>/browse/<slug>/all`. The old paths only redirect, so the start request succeeded, the category pattern matched nothing, and the run finished with zero items and no errors.

## Change

Update the start URLs, the category pattern and the product URL shape. The pattern now pins the locale, which also drops the English-locale link the old pattern accepted. Item extraction is untouched.

## Testing

Both versions were built as throwaway actors and run on the platform with the same input and the same time budget, through the Czech proxy.

| | before | after |
|---|---|---|
| rows | 0, twice | 17147 |
| categories reached | 0 | 16 |
| failed requests | 0 of 1 | 1 of 989 |

The site's own product counts imply 988 category pages. The finishing run made 989 requests, which is those pages plus the start page. All rows carry the required fields, all prices are CZK, there are no duplicate ids, and five sampled product URLs resolve to the product they claim.

Note the site challenges ordinary IPs with a 403 interstitial, so this is hard to check from a laptop. Ground truth above came through the Apify proxy.

## Not in this PR

Two separate problems found while testing, both present before this change:

- A bad opening burst can exhaust the retry budget and abandon whole categories while the run still ends green. It cost 7 of 16 categories in one run of three.
- Seven loose-produce rows carry a price one tenth of the real one.

I will file both separately.
