### PR TITLE
fix(dm): resolve dmLink:// category deep links

### DIFF
--- a/actors/dm-daily/main.js
+++ b/actors/dm-daily/main.js
@@ -203,6 +203,39 @@ function productDetails(json, country, category) {
   };
 }
 
+const SEARCH_RESULT_LINK = "dmlink://searchresult/";
+
+/**
+ * The navigation now points categories at `dmLink://searchresult/<query>`
+ * app deep links, e.g.
+ *   dmLink://searchresult/filters=allCategories.id:010102 isPharmacy:false
+ * Those carry the product query outright, so parse it into the same shape
+ * `productDetails` derives from a category page and skip that hop entirely.
+ * Feeding them to `new URL().pathname` instead builds a content API path that
+ * 404s with an empty `text/plain` body, which is what silently dropped most
+ * of the catalogue.
+ *
+ * Deep links carrying only a `queryTerms` free-text search yield no query:
+ * the search endpoint ignores that parameter, so every one of them returns
+ * the same unfiltered first pages of the catalogue.
+ *
+ * @param {string} link
+ * @returns {Record<string, string> | null} product query, or null when `link`
+ *   holds no filter we can turn into a listing
+ */
+function searchResultQuery(link) {
+  const productQuery = {};
+  for (const [key, value] of new URLSearchParams(link.slice(SEARCH_RESULT_LINK.length))) {
+    if (key !== "filters") continue;
+    // `filters` packs several key:value pairs separated by spaces
+    for (const filter of value.split(" ").filter(Boolean)) {
+      const [filterKey, ...rest] = filter.split(":");
+      productQuery[filterKey] = rest.join(":");
+    }
+  }
+  return Object.keys(productQuery).length > 0 ? productQuery : null;
+}
+
 function categoriesListing({ type, navigation }, stats, country) {
   log.info(`Pagination info ${type}`);
   const requests = [];
@@ -211,11 +244,30 @@ function categoriesListing({ type, navigation }, stats, country) {
   for (const category of traverseCategories(children)) {
     log.debug(`Found category ${category.title} at link: ${category.link}`);
     stats.inc("categories");
-    // Navigation now ships absolute category links (https://www.dm.cz/<path>);
-    // the content API still expects just the path segment appended to the base.
-    const link = new URL(category.link, "https://www.dm.cz").pathname;
     // we need to await here to prevent higher categories
     // to be enqueued sooner than sub-categories
+    if (category.link.toLowerCase().startsWith(SEARCH_RESULT_LINK)) {
+      const productQuery = searchResultQuery(category.link);
+      if (!productQuery) {
+        stats.inc("categoriesSkipped");
+        log.debug(`Skipping search-only category ${category.title}: ${category.link}`);
+        continue;
+      }
+      stats.inc("categoriesFromDeepLink");
+      requests.push({
+        url: makeListingUrl(country, productQuery, 0),
+        userData: {
+          country,
+          category: category.breadcrumbs.toString(),
+          productQuery
+        }
+      });
+      continue;
+    }
+    // Plain content links (https://www.dm.cz/<path>) still go through the
+    // category page; the content API expects just the path segment.
+    const link = new URL(category.link, "https://www.dm.cz").pathname;
+    stats.inc("categoriesFromContentPage");
     requests.push({
       url: `https://content.services.dmtech.com/rootpage-dm-shop-${getCountrySlug(country)}${link}/`,
       userData: {


### PR DESCRIPTION
Closes #3584.

## Problem

The navigation now returns category targets as app deep links:

```
dmLink://searchresult/filters=allCategories.id:010102 isPharmacy:false
```

Passing those through `new URL().pathname` builds a content API path that answers 404 with an empty `text/plain` body. 464 of 556 categories failed that way. Only the few plain `https` links still worked, which is the reported shortfall.

The log names the `text/plain` content type, which reads like a MIME whitelist problem. It is not. The body is empty and the status is 404, so accepting that content type would accept nothing.

## Change

Parse the deep link into the product query and request the listing directly. This also drops one request per category, because the query no longer has to be read back off a category page.

Deep links carrying only `queryTerms` are skipped and logged. The search endpoint ignores that parameter: three different search terms return the same count and the same first product, so each one would re-crawl the same first pages of the catalogue.

## Testing

Both versions were built as throwaway actors and run on the platform with the same input and the same time budget, through the Czech proxy.

| | before | after |
|---|---|---|
| rows | 1159 | 14469 |
| failed requests | 509 | 0 |
| error log lines | 1018 | 0 |

The before number is a ceiling, not a truncation: that run drained its queue and exited in 377 s of a 420 s budget. It also matches the 1.2K in the issue.

14469 is 99.6% of the 14534 products the search API reports. Two other sources agree within 1.7%: the product sitemap has 14721 URLs and the nine top level categories sum to 14788. So the 13K in the issue title is a little low.

Prices agree on 1140 of the 1142 items both versions collect, so only reach changed, not extraction.

## Reviewer notes

The new path makes 625 API requests where the old one made 35, and drew 33 rate-limit responses against 1. All were retried successfully, but it is noticeably more load on dm.

44 of 14469 rows have an empty `category`. They come from brand and facet pages the old version never reached, so this is new surface rather than a regression.

## Not in this PR

#3590 (`slug`) is left out deliberately. dm has three identifiers for one product, and the issue names two: the GTIN, the `dan` in the URL, and the site's own text slug. Setting `slug` to the GTIN is a one line change, but it needs whoever owns the dataset schema to say which one consumers expect. Happy to send it once that is settled.

Also present before this change and not touched: `inStock` is null in every row, the `items` counter double counts, and `itemsUnique` never increments.
