### PR TITLE
fix(dm-daily): add slug to item data and improve query parsing logic

### DIFF
--- a/actors/dm-daily/main.js
+++ b/actors/dm-daily/main.js
@@ -98,6 +98,7 @@ function parseItem(item, country, category) {
   // requires it, so we include it (set to null)
   return {
     itemId: p.gtin,
+    slug: p.gtin,
     itemName: [p.title.preheadline ?? item.brandName, p.title.tileHeadline].filter(Boolean).join(" "),
     itemUrl: createProductUrl(country, p.self),
     img: p.images[0]?.tileSrc ?? null,
@@ -171,14 +172,17 @@ async function saveProducts({ products, stats, processedIds, detailUrl, country,
 /**
  * Navigation links have the form
  * `dmLink://searchresult/filters=allCategories.id:010101 isPharmacy:false`,
- * values may be quoted and repeated keys are joined by `OR`. The search API
- * accepts only one value per key, so alternatives become separate queries.
+ * sometimes preceded by other params (`queryTerms=…&filters=…`), which the
+ * search endpoint ignores. Values may be quoted and repeated keys are joined
+ * by `OR`; the API accepts only one value per key, so alternatives become
+ * separate queries.
  *
  * @param {string} link
  * @returns {Object[]} product queries
  */
 function productQueries(link) {
-  const filters = link.match(/^dmLink:\/\/searchresult\/filters=(.*)$/)?.[1];
+  if (!link.startsWith("dmLink://searchresult/")) return [];
+  const filters = link.match(/(?:^|[?&/])filters=(.*)$/)?.[1];
   if (!filters) return [];
 
   const groups = new Map();


### PR DESCRIPTION
**In this PR:**
1. Addressing issue https://github.com/topmonks/hlidac-shopu/issues/3590. It calls for "make sure slug=itemId is included", mentioned `slug` was fully absent from dataset item schema. 
2. Based on [this comment](https://github.com/topmonks/hlidac-shopu/pull/3592#issuecomment-5392885506), now we have widened `filters= match` that recovers about 30 `queryTerms=…&filters=…` links. The crawl overlaps heavily, so dramatic increase in items count to be observed here.

**Test run:**
https://console.apify.com/actors/tasks/k8lw9MSUzZpT6A89i/runs/e8njh1xpPnCbaDYGE#output

**Please review**
@rarous @katacek @MartinaGelnerova @zuzanalaubeova 