### PR TITLE
fix(aaaauto): rebuild scraper for redesigned site (#3580)

### DIFF
--- a/actors/aaaauto-daily/README.md
+++ b/actors/aaaauto-daily/README.md
@@ -21,19 +21,20 @@ Scrapes prices of all car offers on AAAAuto.cz
 
 ```json
 {
-  "itemUrl": "https://www.aaaauto.sk/sk/hyundai-tucson/car.html?id=399451975#limit=50&promo=b",
-  "itemId": "399451975",
-  "description": "FAMILY, VIN: TMAJ3811AHJ340246",
-  "img": "https://aaaautoeuimg.vshcdn.net/thumb/700097495_640x480x95.jpg?80456",
-  "itemName": "Hyundai Tucson",
-  "currentPrice": "16500",
-  "currency": "Eur",
-  "actionPrice": 14500,
-  "discounted": false,
-  "year": " 2017",
-  "km": " 38 611 km",
-  "transmission": " 6 stupňov",
-  "fuelType": " Benzín",
-  "engine": "1.6 GDI / 97kW"
+  "itemUrl": "https://www.aaaauto.cz/detail/skoda/superb/30311332",
+  "itemId": "30311332",
+  "description": "2.0 TDI, 4x4, Automat, Kuze, Navi",
+  "img": "https://aaaautoeuimg.vshcdn.net/thumb/900590383_1024x768x95.jpg",
+  "itemName": "Skoda Superb",
+  "currentPrice": "210000",
+  "originalPrice": 220000,
+  "currency": "Kc",
+  "actionPrice": 210000,
+  "discounted": true,
+  "year": 2016,
+  "km": "311285 km",
+  "transmission": "Automaticka",
+  "fuelType": "Diesel",
+  "engine": "2.0 TDI"
 }
 ```

--- a/actors/aaaauto-daily/index.js
+++ b/actors/aaaauto-daily/index.js
@@ -1,11 +1,10 @@
-import { createHash } from "node:crypto";
 import { HttpCrawler } from "@crawlee/http";
+import { withPersistedStats } from "@hckr_/apify-persistent-stats";
 import { ActorType } from "@hlidac-shopu/actors-common/actor-type.js";
 import { getInput } from "@hlidac-shopu/actors-common/crawler.js";
 import { parseHTML } from "@hlidac-shopu/actors-common/dom.js";
 import { uploadToKeboola } from "@hlidac-shopu/actors-common/keboola.js";
 import Rollbar from "@hlidac-shopu/actors-common/rollbar.js";
-import { withPersistedStats } from "@hckr_/apify-persistent-stats";
 import { Actor, Dataset, LogLevel, log } from "apify";
 
 /** @typedef {import("linkedom/types/interface/document").Document} Document */
@@ -28,26 +27,20 @@ const categoryByCountry = new Map([
 ]);
 
 /**
+ * @param {Country} country
+ * @returns {string}
+ */
+function originFor(country) {
+  return `https://www.aaaauto.${country.toLocaleLowerCase()}`;
+}
+
+/**
  * @param {ActorType} type
  * @param {Country} country
  * @returns {string}
  */
 export function getRootUrl(type = ActorType.Full, country = Country.CZ) {
-  const tld = country.toLocaleLowerCase();
-  const origin = `https://www.aaaauto.${tld}`;
-  const category = categoryByCountry.get(country);
-  const root = `${origin}/${tld}/cars.php?carlist=1&limit=50&page=1&modern-request&origListURL=%2F${category}%2F`;
-
-  switch (type) {
-    case ActorType.Full:
-      return root;
-    case ActorType.Test:
-      return root.replace("limit=50", "limit=1");
-    case ActorType.BlackFriday:
-      return `${origin}/black-friday/?category=92&limit=50`;
-    default:
-      throw new Error(`Unknown actor type ${type}`);
-  }
+  return getBaseUrl(type, country, 1);
 }
 
 /**
@@ -57,159 +50,62 @@ export function getRootUrl(type = ActorType.Full, country = Country.CZ) {
  * @returns {string}
  */
 export function getBaseUrl(type = ActorType.Full, country = Country.CZ, page = 1) {
-  const tld = country.toLocaleLowerCase();
-  const origin = `https://www.aaaauto.${tld}`;
   const category = categoryByCountry.get(country);
-
-  switch (type) {
-    case ActorType.Test:
-      return `${origin}/${tld}/cars.php?carlist=1&limit=1&page=1&modern-request&origListURL=%2F${category}%2F`;
-    case ActorType.Full:
-      return `${origin}/${tld}/cars.php?carlist=1&limit=50&page=${page}&modern-request&origListURL=%2F${category}%2F`;
-    case ActorType.BlackFriday:
-      return `${origin}/black-friday/?category=92&limit=50&page=${page}`;
-    default:
-      throw new Error(`Unknown actor type ${type}`);
-  }
+  return `${originFor(country)}/${category}/?page=${page}`;
 }
 
 /**
- * @param {string} string
- * @returns {number|undefined}
- */
-export function extractPrice(string) {
-  if (!string) return;
-  const match = string.match(/[\d*\s]*\s[Kč|€]/g);
-  if (!match) return;
-
-  const value = match[0].replace(/\s/g, "").replace("Kč", "").replace("€", "").replace("Cena", "");
-  return parseInt(value);
-}
-
-/**
+ * aaaauto.cz/.sk was rebuilt as an Angular SSR app: the old `cars.php` endpoint 404s and the
+ * catalog now ships as embedded JSON in a `<script type="application/json">` TransferState blob.
+ * Pull the `car-list` message out of it - no browser, no DOM scraping of car cards.
  * @param {Document} document
- * @param {string} country
+ * @returns {{ items: object[], pagination: { totalPages: number } }|null}
  */
-function parseProducts(document, country) {
-  const offers = document.querySelectorAll(".card:has(a.fullSizeLink)");
-  return offers.map(item => {
-    const link = item.querySelector("a.fullSizeLink").href;
-    const figure = item.querySelector("figure");
-    const url = new URL(link);
-    const itemId = url.searchParams.get("id");
-    const itemName = item.querySelector("h2 a").innerText.trim();
-    const arr = itemName.split(",");
-
-    const currentPrice = item.querySelector("span[id*=garageHeart]").getAttribute("data-price");
-    const actionPrice = extractPrice(item.querySelector(".carPrice h3.error:not(.hide)")?.innerText);
-    const originalPrice = extractPrice(item.querySelector(".carPrice .darkGreyAlt")?.innerText);
-    const description = item.querySelector(".carFeatures p").innerText.trim();
-    const carFeatures = item.querySelectorAll(".carFeaturesList li").map(feature => feature.innerText);
-
-    const [km, transmission, fuelType, engine] = carFeatures;
-    return {
-      itemUrl: link,
-      itemId,
-      description,
-      img: figure.querySelector("img").getAttribute("src"),
-      itemName: arr[0],
-      currentPrice,
-      originalPrice,
-      currency: country === Country.CZ ? "Kč" : "Eur",
-      actionPrice,
-      discounted: !!originalPrice,
-      year: arr[1] ? arr[1] : undefined,
-      km,
-      transmission,
-      fuelType,
-      engine
-    };
-  });
-}
-
-const ANUBIS_PASS_PATH = "/.within.website/x/cmd/anubis/api/pass-challenge";
-
-/**
- * aaaauto.cz/.sk sits behind Anubis (Techaro BotStopper), a proof-of-work bot wall.
- * A cold HTTP request gets a tiny challenge page instead of the catalog, which is why
- * the actor silently returned 0 / far-too-few items. We solve the PoW in Node and replay
- * the pass-challenge endpoint to mint the `techaro.lol-anubis-auth` cookie - no browser.
- * @param {string} html
- * @returns {boolean}
- */
-function isAnubisChallenge(html) {
-  return html.includes('id="anubis_challenge"');
+export function extractCarList(document) {
+  const scripts = document.querySelectorAll('script[type="application/json"]');
+  for (const script of scripts) {
+    const text = script.textContent;
+    if (!text || !text.includes('"car-list"')) continue;
+    try {
+      return JSON.parse(text)["car-list"]?.message ?? null;
+    } catch {
+      return null;
+    }
+  }
+  return null;
 }
 
 /**
- * Find a nonce so that sha256(randomData + nonce) has `difficulty` leading hex zeros.
- * Difficulty is 1 in practice (~16 tries), so this is microseconds.
- * @param {string} randomData
- * @param {number} difficulty
- * @returns {{ hash: string, nonce: number }}
+ * @param {object[]} items
+ * @param {Country} country
  */
-function solveAnubisPow(randomData, difficulty) {
-  const prefix = "0".repeat(difficulty);
-  for (let nonce = 0; ; nonce++) {
-    const hash = createHash("sha256").update(`${randomData}${nonce}`).digest("hex");
-    if (hash.startsWith(prefix)) return { hash, nonce };
-  }
-}
-
-/**
- * Build the pass-challenge URL that mints the auth cookie for the given challenge page.
- * Handles both Anubis algorithms the site rotates through: `fast`/`slow` (PoW) and `metarefresh` (no PoW).
- * @param {string} html challenge page HTML
- * @param {string} pageUrl the URL we were trying to reach
- * @returns {string|null}
- */
-function buildAnubisPassUrl(html, pageUrl) {
-  const match = html.match(/<script id="anubis_challenge"[^>]*>([\s\S]*?)<\/script>/);
-  if (!match) return null;
-  const parsed = JSON.parse(match[1].trim());
-  // An "oops" page (rejected/stale pass) carries a null challenge - bail so the caller retries cleanly.
-  if (!parsed?.challenge || !parsed?.rules) return null;
-  const { challenge, rules } = parsed;
-  const { origin } = new URL(pageUrl);
-
-  if (rules.algorithm === "metarefresh") {
-    // The server already baked the full pass-challenge URL into the meta refresh tag.
-    const meta = html.match(/http-equiv="refresh"[^>]*url=([^"]+)"/i);
-    if (meta) return new URL(meta[1].replace(/&amp;/g, "&"), origin).toString();
-    const params = new URLSearchParams({ challenge: challenge.randomData, id: challenge.id, redir: pageUrl });
-    return `${origin}${ANUBIS_PASS_PATH}?${params}`;
-  }
-
-  const start = Date.now();
-  const { hash, nonce } = solveAnubisPow(challenge.randomData, rules.difficulty);
-  const params = new URLSearchParams({
-    id: challenge.id,
-    response: hash,
-    nonce: String(nonce),
-    redir: pageUrl,
-    elapsedTime: String(1200 + (Date.now() - start))
-  });
-  return `${origin}${ANUBIS_PASS_PATH}?${params}`;
-}
-
-/**
- * Return the real HTML for `url`, transparently clearing the Anubis wall if it is served.
- * `sendRequest` reuses the crawler session's proxy + cookie jar, so the minted auth cookie
- * is stored and replayed on the session's subsequent page requests.
- * @param {{ url: string, html: string, sendRequest: Function }} args
- * @returns {Promise<string>}
- */
-async function solveAnubisIfNeeded({ url, html, sendRequest }) {
-  for (let attempt = 0; attempt < 3 && isAnubisChallenge(html); attempt++) {
-    const passUrl = buildAnubisPassUrl(html, url);
-    if (!passUrl) break;
-    const response = await sendRequest({ url: passUrl });
-    html = response.body.toString();
-  }
-  if (isAnubisChallenge(html)) {
-    throw new Error(`AAAauto: failed to solve Anubis challenge for ${url}`);
-  }
-  return html;
+export function parseProducts(items, country) {
+  const tld = country.toLocaleLowerCase();
+  return items
+    .filter(item => !item.isSold)
+    .map(item => {
+      const itemUrl = `https://www.aaaauto.${tld}/detail/${item.make?.slug}/${item.model?.slug}/${item.id}`;
+      const currentPrice = item.price?.cash;
+      const oldCash = Number(item.price?.oldCash);
+      const discounted = oldCash > 0 && oldCash > Number(currentPrice);
+      return {
+        itemUrl,
+        itemId: String(item.id),
+        description: item.webHeadline,
+        img: item.photos?.default?.[0],
+        itemName: item.displayTitle,
+        currentPrice,
+        originalPrice: discounted ? oldCash : undefined,
+        currency: country === Country.CZ ? "Kč" : "Eur",
+        actionPrice: discounted ? Number(currentPrice) : undefined,
+        discounted,
+        year: item.productionYear,
+        km: item.mileage != null ? `${item.mileage} ${item.mileageUnit ?? "km"}` : undefined,
+        transmission: item.gearbox?.title,
+        fuelType: item.fuel?.title,
+        engine: item.engine?.title
+      };
+    });
 }
 
 export async function main() {
@@ -218,8 +114,6 @@ export async function main() {
   const {
     development,
     debug,
-    // AAA intermittently soft-blocks past Anubis with a "page not found" decoy, so each page may
-    // need a few fresh-session retries to land a real catalog response. Default higher than Crawlee's 3.
     maxRequestRetries = 8,
     type = ActorType.Full,
     proxyGroups,
@@ -252,49 +146,36 @@ export async function main() {
     persistCookiesPerSession: true,
     requestHandlerTimeoutSecs: 300,
     navigationTimeoutSecs: 300,
-    async requestHandler({ request, body, sendRequest, session }) {
-      const html = await solveAnubisIfNeeded({ url: request.url, html: body.toString(), sendRequest });
-      const { document } = parseHTML(html);
-
+    async requestHandler({ request, body, session }) {
+      const { document } = parseHTML(body.toString());
       const { label } = request.userData;
       log.info(`Label: ${label} - Scraping page ${request.url}`);
 
-      // Past Anubis, AAA intermittently returns a 200 OK "Stránka nenalezena" (page not found) decoy
-      // that parses to zero products - a silent block. Retire the session (fresh proxy IP on retry)
-      // and throw so Crawlee re-fetches the page instead of recording an empty success.
+      // A response without the car-list payload is an SSR miss / soft-block. Retire the session
+      // (fresh proxy IP on retry) and throw so Crawlee re-fetches instead of recording an empty success.
+      const message = extractCarList(document);
       const softBlocked = () => {
         session?.retire();
-        throw new Error(`AAAauto: soft-block "page not found" decoy on ${request.url} - retrying with a fresh session`);
+        throw new Error(`AAAauto: missing car-list payload on ${request.url} - retrying with a fresh session`);
       };
+      if (!message) return softBlocked();
 
-      switch (label) {
-        case Label.START:
-          {
-            const pages = document.querySelectorAll("nav.pagenav li");
-            const lastPageLink = pages[pages.length - 2]?.querySelector("a");
-            if (!lastPageLink) return softBlocked();
-            const lastPage = parseInt(lastPageLink.innerText.trim());
+      const products = parseProducts(message.items ?? [], country);
+      if (products.length === 0) return softBlocked();
+      await Dataset.pushData(products);
 
-            const requests = [];
-            for (let i = 0; i < lastPage; i++) {
-              const pageNumber = i + 1;
-              requests.push({
-                url: getBaseUrl(type, country, pageNumber),
-                userData: { label: Label.PAGE, pageNumber }
-              });
-            }
-            const products = parseProducts(document, country);
-            await Promise.allSettled([crawler.requestQueue.addRequests(requests), Dataset.pushData(products)]);
-          }
-          break;
-        case Label.PAGE:
-          {
-            const products = parseProducts(document, country);
-            if (products.length === 0) return softBlocked();
-            await Dataset.pushData(products);
-          }
-          break;
+      if (label === Label.START && type !== ActorType.Test) {
+        const totalPages = message.pagination?.totalPages ?? 1;
+        const requests = [];
+        for (let page = 2; page <= totalPages; page++) {
+          requests.push({
+            url: getBaseUrl(type, country, page),
+            userData: { label: Label.PAGE, pageNumber: page }
+          });
+        }
+        if (requests.length) await crawler.requestQueue.addRequests(requests);
       }
+
       stats.inc("urls");
     },
     async failedRequestHandler({ request }, error) {

--- a/actors/aaaauto-daily/index.js
+++ b/actors/aaaauto-daily/index.js
@@ -50,6 +50,12 @@ export function getRootUrl(type = ActorType.Full, country = Country.CZ) {
  * @returns {string}
  */
 export function getBaseUrl(type = ActorType.Full, country = Country.CZ, page = 1) {
+  // The old site had a dedicated Black Friday listing (`/black-friday/?category=92`). That URL is
+  // gone with the redesign and no replacement is known yet, so fail loudly rather than silently
+  // scrape the full catalog into the `_bf` table. Revisit when the BF section goes live. See #3580.
+  if (type === ActorType.BlackFriday) {
+    throw new Error("AAAauto: Black Friday URL is unknown after the site redesign - not yet supported (see #3580)");
+  }
   const category = categoryByCountry.get(country);
   return `${originFor(country)}/${category}/?page=${page}`;
 }

--- a/actors/aaaauto-daily/index.test.mjs
+++ b/actors/aaaauto-daily/index.test.mjs
@@ -1,7 +1,43 @@
 import test from "ava";
-import { extractPrice } from "./index.js";
+import { Country, parseProducts } from "./index.js";
 
-test("extractPrice", t => {
-  const result = extractPrice("1 000 000 Kč");
-  t.is(result, 1000000);
+// Trimmed shape of a real car-list.message.items[] entry (aaaauto Angular SSR payload).
+const item = {
+  id: 30311332,
+  isSold: false,
+  displayTitle: "Škoda Superb",
+  webHeadline: "2.0 TDI, 4x4, Automat",
+  productionYear: 2016,
+  mileage: 311285,
+  mileageUnit: "km",
+  make: { slug: "skoda" },
+  model: { slug: "superb" },
+  gearbox: { title: "Automatická" },
+  fuel: { title: "Diesel" },
+  engine: { title: "2.0 TDI" },
+  photos: { default: ["https://img/900590383_1024x768x95.jpg"] },
+  price: { cash: "210000", oldCash: "220000" }
+};
+
+test("parseProducts maps a discounted car", t => {
+  const [p] = parseProducts([item], Country.CZ);
+  t.is(p.itemId, "30311332");
+  t.is(p.itemUrl, "https://www.aaaauto.cz/detail/skoda/superb/30311332");
+  t.is(p.itemName, "Škoda Superb");
+  t.is(p.currentPrice, "210000");
+  t.is(p.originalPrice, 220000);
+  t.true(p.discounted);
+  t.is(p.currency, "Kč");
+  t.is(p.km, "311285 km");
+});
+
+test("parseProducts skips sold cars and non-discounted has no originalPrice", t => {
+  const sold = { ...item, isSold: true };
+  t.is(parseProducts([sold], Country.CZ).length, 0);
+
+  const full = { ...item, price: { cash: "210000", oldCash: "0" } };
+  const [p] = parseProducts([full], Country.SK);
+  t.false(p.discounted);
+  t.is(p.originalPrice, undefined);
+  t.is(p.currency, "Eur");
 });


### PR DESCRIPTION
## What & why

`aaaauto-daily` returns **0 items** with `Proxy responded with 590 UPSTREAM502: 0 bytes` (#3580).

Root cause: **aaaauto.cz/.sk was fully rebuilt as an Angular SSR app.**
- The old endpoint `…/cars.php?carlist=1&…` now **404s** → that's the `590 UPSTREAM502` (the request fails at the proxy before our handler runs).
- Every old DOM selector is dead (`a.fullSizeLink`, `span[id*=garageHeart]`, `.carFeaturesList`, `nav.pagenav`).
- The Anubis PoW wall is **gone** — the June fix is now dead code, removed here.

The catalog now ships as embedded JSON in a `<script type="application/json">` TransferState blob. The car list lives at `car-list.message.items[]` with `pagination.totalPages`.

## Changes
- New URL: `https://www.aaaauto.{cz,sk}/{ojete-vozy,ojazdene-vozidla}/?page=N`.
- `parseProducts` now maps the JSON objects → same dataset schema (itemId, itemUrl, itemName, currentPrice, originalPrice, currency, discounted, year, km, transmission, fuelType, engine, img, description). Sold cars filtered out.
- Pagination from `pagination.totalPages`; `ActorType.Test` fetches page 1 only.
- Kept the soft-block guard (retire session + throw on missing/empty payload) and the keboola/rollbar/stats scaffolding.
- Updated README output sample and the unit test.

## ⚠️ Behavior changes vs. the original (please review)
- **Black Friday is intentionally NOT supported yet.** The old actor had a dedicated BF listing (`/black-friday/?category=92`); that URL is gone with the redesign and I can't verify its replacement in August. Rather than silently scrape the **full catalog** into the `_bf` keboola table, `type=BlackFriday` now **throws a clear error** (`getBaseUrl`). This must be wired to the real BF URL before November. `Full` and `Test` are unaffected.
- **`ActorType.Test`** no longer means "1 item" (old `limit=1`); the new site has a fixed 35/page, so Test fetches **page 1 only** (~35 items) and enqueues no further pages. Same "quick run" intent, different mechanism.
- **`itemId` scheme changed** to the redesigned site's detail id (`item.id`, used in `/detail/{make}/{model}/{id}`). Price history keyed on the old id won't carry over — unavoidable given the rebuild.

## Testing
- Parser verified against live-saved pages (CZ p1/p2, SK): **35/35 items parse cleanly**, valid detail URLs / prices / images.
- Biome check passes.
- Platform-tested on a personal account through Apify Proxy — see the results comment below (CZ + SK, `type=TEST`, both 35 items with correct mapping).