### PR TITLE
fix(aaaauto): restore slug, repair extension after redesign (#3580)

### DIFF
--- a/actors/AGENT.md
+++ b/actors/AGENT.md
@@ -103,7 +103,9 @@ fixing only the actor leaves the price history unreachable. All three must agree
    bogus slug.
 3. **`extension/shops/<shop>.mjs`** - the content script needs the id too, but it bundles
    `@hlidac-shopu/lib` as a workspace dependency, so it *can* share the parser: use
-   `getItemIdFromUrl(location)` from `extension/helpers.mjs` rather than copying the regex.
+   `getItemIdFromUrl(new URL(location.href))` from `extension/helpers.mjs` rather than
+   copying the regex. Pass a real `URL` - the helper hands it straight to `parse`, and a
+   bare `location` has no `searchParams`.
 
 **Trap:** an actor's Docker image installs the *published* `@hlidac-shopu/actors-common`
 (and through it `@hlidac-shopu/lib`), not this repo's working copy. Importing `itemSlug`

--- a/actors/AGENT.md
+++ b/actors/AGENT.md
@@ -103,8 +103,7 @@ fixing only the actor leaves the price history unreachable. All three must agree
    bogus slug.
 3. **`extension/shops/<shop>.mjs`** - the content script needs the id too, but it bundles
    `@hlidac-shopu/lib` as a workspace dependency, so it *can* share the parser: use
-   `getItemIdFromUrl(new URL(location.href))` from `extension/helpers.mjs` rather than
-   copying the regex. Pass a `URL`, not `location` - a `Location` has no `searchParams`.
+   `getItemIdFromUrl(location)` from `extension/helpers.mjs` rather than copying the regex.
 
 **Trap:** an actor's Docker image installs the *published* `@hlidac-shopu/actors-common`
 (and through it `@hlidac-shopu/lib`), not this repo's working copy. Importing `itemSlug`

--- a/actors/AGENT.md
+++ b/actors/AGENT.md
@@ -101,8 +101,10 @@ fixing only the actor leaves the price history unreachable. All three must agree
    dead even though the actor looks healthy. Keep the old URL form working: URLs already
    in stored history are still parsed. Guard non-detail pages, or a listing page yields a
    bogus slug.
-3. **`extension/shops/<shop>.mjs`** - the content script scrapes its own `itemId` and does
-   *not* share the `lib/shops.mjs` parser. It needs the same change separately.
+3. **`extension/shops/<shop>.mjs`** - the content script needs the id too, but it bundles
+   `@hlidac-shopu/lib` as a workspace dependency, so it *can* share the parser: use
+   `getItemIdFromUrl(new URL(location.href))` from `extension/helpers.mjs` rather than
+   copying the regex. Pass a `URL`, not `location` - a `Location` has no `searchParams`.
 
 **Trap:** an actor's Docker image installs the *published* `@hlidac-shopu/actors-common`
 (and through it `@hlidac-shopu/lib`), not this repo's working copy. Importing `itemSlug`

--- a/actors/AGENT.md
+++ b/actors/AGENT.md
@@ -89,6 +89,28 @@ const data = JSON.parse(response.body);
 const totalPages = data.pagination?.totalPages || 1;
 ```
 
+### Redesigns That Change the Product URL
+
+A redesign that moves the product id inside the URL breaks three places at once, and
+fixing only the actor leaves the price history unreachable. All three must agree:
+
+1. **Actor dataset** - must push a `slug` (see `actors/NOTES.md`); it is the price-history
+   key `items/{shop}/{slug}/price-history.json`.
+2. **`lib/shops.mjs`** - the shop's `parse(url)` derives the slug from the *detail URL*.
+   `api.hlidacshopu.cz` answers "Missing slug" when it returns nothing, so the chart is
+   dead even though the actor looks healthy. Keep the old URL form working: URLs already
+   in stored history are still parsed. Guard non-detail pages, or a listing page yields a
+   bogus slug.
+3. **`extension/shops/<shop>.mjs`** - the content script scrapes its own `itemId` and does
+   *not* share the `lib/shops.mjs` parser. It needs the same change separately.
+
+**Trap:** an actor's Docker image installs the *published* `@hlidac-shopu/actors-common`
+(and through it `@hlidac-shopu/lib`), not this repo's working copy. Importing `itemSlug`
+inside an actor therefore resolves to the released parser, which lags a fix in `lib/`.
+Compute the slug in the actor and pin the contract with a test in `lib/shops.test.mjs`.
+
+Worked example: aaaauto (#3580), `?id=` -> `/detail/{make}/{model}/{id}`.
+
 ## Debugging Workflow
 
 ### 1. Verify the Issue

--- a/actors/NOTES.md
+++ b/actors/NOTES.md
@@ -61,7 +61,7 @@ describe("shopSlug", () => {
 ```
 shop* -- use `shopName` function from `@hlidacshopu/actors-common/product.js`
 shopOrigin -- use `shopOrigin` function from `@hlidacshopu/actors-common/product.js`
-slug*  -- our product identifier used as key in KV story, has to be unique on the origin/shop; use `itemSlug` function from `@hlidacshopu/actors-common/product.js`
+slug*  -- our product identifier used as key in KV story, has to be unique on the origin/shop; use `itemSlug` function from `@hlidacshopu/actors-common/product.js` -- but note it resolves to the *published* lib inside an actor image, so if the shop's URL shape just changed, compute the slug in the actor instead (see "Redesigns That Change the Product URL" in AGENT.md)
 itemId* -- origin/shop ID, SKU or GTIN
 itemUrl* -- full absolute URL of the product detail page
 itemName*

--- a/actors/aaaauto-daily/README.md
+++ b/actors/aaaauto-daily/README.md
@@ -23,6 +23,7 @@ Scrapes prices of all car offers on AAAAuto.cz
 {
   "itemUrl": "https://www.aaaauto.cz/detail/skoda/superb/30311332",
   "itemId": "30311332",
+  "slug": "30311332",
   "description": "2.0 TDI, 4x4, Automat, Kuze, Navi",
   "img": "https://aaaautoeuimg.vshcdn.net/thumb/900590383_1024x768x95.jpg",
   "itemName": "Skoda Superb",

--- a/actors/aaaauto-daily/index.js
+++ b/actors/aaaauto-daily/index.js
@@ -97,6 +97,10 @@ export function parseProducts(items, country) {
       return {
         itemUrl,
         itemId: String(item.id),
+        // Price-history key (`items/{shop}/{slug}/...`). Must stay identical to what `itemSlug` from
+        // @hlidac-shopu/lib derives from `itemUrl` - see the aaaauto case in lib/shops.test.mjs.
+        // Inlined rather than imported: the actor image installs the *published* lib, which lags this repo.
+        slug: String(item.id),
         description: item.webHeadline,
         img: item.photos?.default?.[0],
         itemName: item.displayTitle,

--- a/actors/aaaauto-daily/index.js
+++ b/actors/aaaauto-daily/index.js
@@ -97,9 +97,8 @@ export function parseProducts(items, country) {
       return {
         itemUrl,
         itemId: String(item.id),
-        // Price-history key (`items/{shop}/{slug}/...`). Must stay identical to what `itemSlug` from
-        // @hlidac-shopu/lib derives from `itemUrl` - see the aaaauto case in lib/shops.test.mjs.
-        // Inlined rather than imported: the actor image installs the *published* lib, which lags this repo.
+        // Price-history key; must equal itemSlug(itemUrl) - pinned in lib/shops.test.mjs.
+        // Not imported: the actor image installs the published lib. See actors/AGENT.md.
         slug: String(item.id),
         description: item.webHeadline,
         img: item.photos?.default?.[0],

--- a/actors/aaaauto-daily/index.test.mjs
+++ b/actors/aaaauto-daily/index.test.mjs
@@ -22,6 +22,7 @@ const item = {
 test("parseProducts maps a discounted car", t => {
   const [p] = parseProducts([item], Country.CZ);
   t.is(p.itemId, "30311332");
+  t.is(p.slug, "30311332");
   t.is(p.itemUrl, "https://www.aaaauto.cz/detail/skoda/superb/30311332");
   t.is(p.itemName, "Škoda Superb");
   t.is(p.currentPrice, "210000");

--- a/extension/helpers.mjs
+++ b/extension/helpers.mjs
@@ -52,7 +52,9 @@ export function getShop(url) {
 
 export function getItemIdFromUrl(url) {
   const shop = shops_lib.get(shopName(url));
-  return shop.parse(url).itemId;
+  // `new URL` normalizes a string, a URL or a `location` - the last of which has `search`
+  // but no `searchParams`, so a shop whose parse reads query params would throw on it.
+  return shop.parse(new URL(url)).itemId;
 }
 
 /**

--- a/extension/helpers.mjs
+++ b/extension/helpers.mjs
@@ -51,10 +51,11 @@ export function getShop(url) {
 }
 
 export function getItemIdFromUrl(url) {
-  const shop = shops_lib.get(shopName(url));
   // `new URL` normalizes a string, a URL or a `location` - the last of which has `search`
   // but no `searchParams`, so a shop whose parse reads query params would throw on it.
-  return shop.parse(new URL(url)).itemId;
+  // Unknown host returns null rather than throwing, like `getShop` above: callers may pass
+  // a url the page gave them (a JSON-LD `url`), not just `location`.
+  return shops_lib.get(shopName(url))?.parse(new URL(url))?.itemId ?? null;
 }
 
 /**

--- a/extension/helpers.mjs
+++ b/extension/helpers.mjs
@@ -51,11 +51,8 @@ export function getShop(url) {
 }
 
 export function getItemIdFromUrl(url) {
-  // `new URL` normalizes a string, a URL or a `location` - the last of which has `search`
-  // but no `searchParams`, so a shop whose parse reads query params would throw on it.
-  // Unknown host returns null rather than throwing, like `getShop` above: callers may pass
-  // a url the page gave them (a JSON-LD `url`), not just `location`.
-  return shops_lib.get(shopName(url))?.parse(new URL(url))?.itemId ?? null;
+  const shop = shops_lib.get(shopName(url));
+  return shop.parse(url).itemId;
 }
 
 /**

--- a/extension/shops/aaaauto.mjs
+++ b/extension/shops/aaaauto.mjs
@@ -34,7 +34,8 @@ export class AAAAuto extends AsyncShop {
   get injectionPoint() {
     // The price block sits in a flex row, so a sibling there gets squeezed; the
     // `.detail__header` wrapper is block-level, full width, and present in both templates.
-    return ["afterend", ".detail__header"];
+    // Width capped as before the redesign - the wrapper's container is ~1120px wide.
+    return ["afterend", ".detail__header", { "max-width": "640px", margin: "2em auto" }];
   }
 
   get waitForSelector() {

--- a/extension/shops/aaaauto.mjs
+++ b/extension/shops/aaaauto.mjs
@@ -38,7 +38,7 @@ export class AAAAuto extends AsyncShop {
 
   async scrape() {
     // Shares lib/shops.mjs, so the extension tracks the URL parser instead of copying it.
-    const itemId = getItemIdFromUrl(new URL(location.href));
+    const itemId = getItemIdFromUrl(location);
     if (!itemId) return null;
 
     const product = jsonLdProduct();

--- a/extension/shops/aaaauto.mjs
+++ b/extension/shops/aaaauto.mjs
@@ -56,7 +56,8 @@ export class AAAAuto extends AsyncShop {
     const currentPrice = cleanPriceText(product.offers.price);
     if (!currentPrice) return null;
 
-    const title = document.querySelector("h1")?.textContent.trim() ?? product.name;
+    // JSON-LD `name` is the clean car name; the page h1 appends the year in a nested span.
+    const title = product.name ?? document.querySelector("h1")?.textContent.trim();
     const image = product.image;
     const imageUrl =
       (Array.isArray(image) ? image[0] : image) ?? document.querySelector("meta[property='og:image']")?.content;

--- a/extension/shops/aaaauto.mjs
+++ b/extension/shops/aaaauto.mjs
@@ -1,55 +1,65 @@
-import { cleanPrice, registerShop } from "../helpers.mjs";
-import { Shop } from "./shop.mjs";
+import { cleanPriceText, registerShop } from "../helpers.mjs";
+import { AsyncShop } from "./shop.mjs";
 
-export class AAAAuto extends Shop {
-  async scrape() {
-    const url = new URL(location.href);
-    const itemId = url.searchParams.get("id");
-    if (!itemId) return;
-    const imageUrl = document.querySelector("meta[property='og:image']")?.content;
+/**
+ * Redesigned aaaauto is an Angular SPA. Car detail lives at /detail/{make}/{model}/{id},
+ * often with a routing hash appended; the old `?id=` param is gone.
+ *
+ * Price/name/image come from the page's schema.org JSON-LD rather than from selectors,
+ * because there is no single markup to select against:
+ * - .cz renders the current price block (`.detail-price-block__price--main`),
+ * - .sk still renders the legacy one (`.price__amount--default`),
+ * and neither survives as a stable contract. The JSON-LD `offers.price` is the cash
+ * price on both - the same number the aaaauto-daily actor stores as `currentPrice` -
+ * and Angular re-renders it on client-side navigation, which the server-side
+ * `#ng-state` blob does not (it only holds the car loaded on first paint).
+ */
+const DETAIL_PATH = /^\/detail\/[^/]+\/[^/]+\/(\d+)/;
 
-    // eng variant
-    const engTabCard = document.querySelector("#tab-card");
-    if (engTabCard) {
-      const title = engTabCard.querySelector("h1").textContent;
-      const priceRows = engTabCard.querySelectorAll("#priceTable .priceRow");
-      let currentPrice;
-      if (priceRows.length === 2) {
-        currentPrice = cleanPrice(engTabCard.querySelector("#priceTable .carPrice span"));
-      } else {
-        currentPrice = cleanPrice(engTabCard.querySelector("#priceTable .priceRow:last-child span"));
-      }
-
-      const originalPrice = null;
-      return { itemId, title, currentPrice, originalPrice, imageUrl };
+/** @returns {{name: string, offers: {price: string}, image: string|string[]}|null} */
+function jsonLdProduct() {
+  for (const script of document.querySelectorAll('script[type="application/ld+json"]')) {
+    try {
+      const graph = JSON.parse(script.textContent)["@graph"] ?? [];
+      const product = graph.find(node => node.offers?.price);
+      if (product) return product;
+    } catch {
+      // A malformed block must not stop us from reading the next one.
     }
+  }
+  return null;
+}
 
-    const title = document.querySelector(".carCard__name h1")?.innerText.trim().replaceAll(/\s+/g, " ");
-    const originalPrice = cleanPrice(document.querySelector(".carCard__price-item s"));
-    const currentPrice = cleanPrice(document.querySelector(".carCard__price-value:not(.secondary)"));
-    return { itemId, title, currentPrice, originalPrice, imageUrl };
+export class AAAAuto extends AsyncShop {
+  get injectionPoint() {
+    // The price block sits in a flex row, so a sibling there gets squeezed; the
+    // `.detail__header` wrapper is block-level, full width, and present in both templates.
+    return ["afterend", ".detail__header"];
   }
 
-  inject(renderMarkup) {
-    let elem = document.querySelector(".carCard__head");
-    if (elem) {
-      const markup = renderMarkup({
-        "max-width": "640px",
-        margin: "2em auto"
-      });
-      elem.insertAdjacentElement("afterend", markup);
-      return elem;
-    }
+  get waitForSelector() {
+    return ".detail__header";
+  }
 
-    // eng variant
-    elem = document.querySelector("#carButtons .testdrive-bonus");
-    if (!elem) throw new Error("Element to add chart not found");
+  async scrape() {
+    const itemId = location.pathname.match(DETAIL_PATH)?.[1];
+    if (!itemId) return null;
 
-    const table = document.querySelector("#carButtons table");
-    table.style.position = "relative";
-    const markup = renderMarkup();
-    elem.insertAdjacentElement("afterend", markup);
-    return elem;
+    const product = jsonLdProduct();
+    if (!product) return null;
+
+    const currentPrice = cleanPriceText(product.offers.price);
+    if (!currentPrice) return null;
+
+    const title = document.querySelector("h1")?.textContent.trim() ?? product.name;
+    const image = product.image;
+    const imageUrl =
+      (Array.isArray(image) ? image[0] : image) ?? document.querySelector("meta[property='og:image']")?.content;
+
+    // No pre-discount price is published anywhere on the detail page. The second price
+    // shown next to the main one ("Akční cena" / secondary) is the financed price, not a
+    // former price - reporting it as originalPrice would invent a discount.
+    return { itemId, title, currentPrice, originalPrice: null, imageUrl };
   }
 }
 

--- a/extension/shops/aaaauto.mjs
+++ b/extension/shops/aaaauto.mjs
@@ -38,7 +38,8 @@ export class AAAAuto extends AsyncShop {
 
   async scrape() {
     // Shares lib/shops.mjs, so the extension tracks the URL parser instead of copying it.
-    const itemId = getItemIdFromUrl(location);
+    const url = new URL(window.location.href);
+    const itemId = getItemIdFromUrl(url);
     if (!itemId) return null;
 
     const product = jsonLdProduct();
@@ -48,7 +49,9 @@ export class AAAAuto extends AsyncShop {
     // hop the JSON-LD may still describe the previous car; a mis-paired price is persisted
     // server-side for 24h. Compare through the same parser so a trailing slash or a query
     // on the canonical url cannot silently reject every car. Bail and let the observer retry.
-    if (getItemIdFromUrl(new URL(product.url ?? "", location.href)) !== itemId) return null;
+    // The canonical url comes from the page, so check the host before parsing it as ours.
+    const canonical = new URL(product.url ?? "", url);
+    if (canonical.host !== url.host || getItemIdFromUrl(canonical) !== itemId) return null;
 
     // String(): schema.org allows a numeric price, and cleanPriceText calls .replace on it.
     const currentPrice = cleanPriceText(String(product.offers.price));

--- a/extension/shops/aaaauto.mjs
+++ b/extension/shops/aaaauto.mjs
@@ -18,7 +18,9 @@ import { AsyncShop } from "./shop.mjs";
 function jsonLdProduct() {
   for (const script of document.querySelectorAll('script[type="application/ld+json"]')) {
     try {
-      const graph = JSON.parse(script.textContent)["@graph"] ?? [];
+      const data = JSON.parse(script.textContent);
+      // Both TLDs ship an @graph today; a flat or array-rooted block is still valid JSON-LD.
+      const graph = data["@graph"] ?? (Array.isArray(data) ? data : [data]);
       const product = graph.find(node => node.offers?.price);
       if (product) return product;
     } catch {
@@ -53,7 +55,8 @@ export class AAAAuto extends AsyncShop {
     // the observer retry on the next mutation.
     if (!product.url?.endsWith(`/${itemId}`)) return null;
 
-    const currentPrice = cleanPriceText(product.offers.price);
+    // String(): schema.org allows a numeric price, and cleanPriceText calls .replace on it.
+    const currentPrice = cleanPriceText(String(product.offers.price));
     if (!currentPrice) return null;
 
     // JSON-LD `name` is the clean car name; the page h1 appends the year in a nested span.

--- a/extension/shops/aaaauto.mjs
+++ b/extension/shops/aaaauto.mjs
@@ -2,17 +2,12 @@ import { cleanPriceText, getItemIdFromUrl, registerShop } from "../helpers.mjs";
 import { AsyncShop } from "./shop.mjs";
 
 /**
- * Redesigned aaaauto is an Angular SPA. Car detail lives at /detail/{make}/{model}/{id},
- * often with a routing hash appended; the old `?id=` param is gone.
- *
- * Price/name/image come from the page's schema.org JSON-LD rather than from selectors,
- * because there is no single markup to select against:
- * - .cz renders the current price block (`.detail-price-block__price--main`),
- * - .sk still renders the legacy one (`.price__amount--default`),
- * and neither survives as a stable contract. The JSON-LD `offers.price` is the cash
- * price on both - the same number the aaaauto-daily actor stores as `currentPrice` -
- * and Angular re-renders it on client-side navigation, which the server-side
- * `#ng-state` blob does not (it only holds the car loaded on first paint).
+ * Redesigned aaaauto is an Angular SPA; detail is /detail/{make}/{model}/{id}, no more `?id=`.
+ * Price/name/image come from the schema.org JSON-LD because the price markup varies by
+ * rollout bucket (`.detail-price-block__price--main` vs the legacy `.price__amount--default`,
+ * seen on both TLDs), while `offers.price` is the cash price everywhere - the same number
+ * the aaaauto-daily actor stores. See "Redesigns That Change the Product URL" in
+ * actors/AGENT.md for the slug contract this feeds.
  */
 /** @returns {{name: string, offers: {price: string}, image: string|string[]}|null} */
 function jsonLdProduct() {
@@ -32,9 +27,8 @@ function jsonLdProduct() {
 
 export class AAAAuto extends AsyncShop {
   get injectionPoint() {
-    // The price block sits in a flex row, so a sibling there gets squeezed; the
-    // `.detail__header` wrapper is block-level, full width, and present in both templates.
-    // Width capped as before the redesign - the wrapper's container is ~1120px wide.
+    // A sibling of the price block gets squeezed by its flex row; `.detail__header` is
+    // block-level and present in both buckets. Width capped as before the redesign.
     return ["afterend", ".detail__header", { "max-width": "640px", margin: "2em auto" }];
   }
 
@@ -50,10 +44,9 @@ export class AAAAuto extends AsyncShop {
     const product = jsonLdProduct();
     if (!product) return null;
 
-    // Angular pushes the new URL before it swaps the detail subtree, so on a client-side
-    // detail -> detail hop the JSON-LD can still describe the previous car. Pairing that
-    // price with this id would persist a wrong price server-side for 24h, so bail and let
-    // the observer retry on the next mutation.
+    // Angular pushes the new URL before swapping the subtree, so after a detail -> detail
+    // hop the JSON-LD may still describe the previous car; a mis-paired price is persisted
+    // server-side for 24h. Bail and let the observer retry.
     if (!product.url?.endsWith(`/${itemId}`)) return null;
 
     // String(): schema.org allows a numeric price, and cleanPriceText calls .replace on it.
@@ -66,9 +59,8 @@ export class AAAAuto extends AsyncShop {
     const imageUrl =
       (Array.isArray(image) ? image[0] : image) ?? document.querySelector("meta[property='og:image']")?.content;
 
-    // No pre-discount price is published anywhere on the detail page. The second price
-    // shown next to the main one ("Akční cena" / secondary) is the financed price, not a
-    // former price - reporting it as originalPrice would invent a discount.
+    // The second price on the page ("Akční cena" / secondary) is the financed price, not a
+    // former price, and no pre-discount price is published - so originalPrice stays null.
     return { itemId, title, currentPrice, originalPrice: null, imageUrl };
   }
 }

--- a/extension/shops/aaaauto.mjs
+++ b/extension/shops/aaaauto.mjs
@@ -1,4 +1,4 @@
-import { cleanPriceText, registerShop } from "../helpers.mjs";
+import { cleanPriceText, getItemIdFromUrl, registerShop } from "../helpers.mjs";
 import { AsyncShop } from "./shop.mjs";
 
 /**
@@ -14,8 +14,6 @@ import { AsyncShop } from "./shop.mjs";
  * and Angular re-renders it on client-side navigation, which the server-side
  * `#ng-state` blob does not (it only holds the car loaded on first paint).
  */
-const DETAIL_PATH = /^\/detail\/[^/]+\/[^/]+\/(\d+)/;
-
 /** @returns {{name: string, offers: {price: string}, image: string|string[]}|null} */
 function jsonLdProduct() {
   for (const script of document.querySelectorAll('script[type="application/ld+json"]')) {
@@ -42,7 +40,8 @@ export class AAAAuto extends AsyncShop {
   }
 
   async scrape() {
-    const itemId = location.pathname.match(DETAIL_PATH)?.[1];
+    // Shares lib/shops.mjs, so the extension tracks the URL parser instead of copying it.
+    const itemId = getItemIdFromUrl(new URL(location.href));
     if (!itemId) return null;
 
     const product = jsonLdProduct();

--- a/extension/shops/aaaauto.mjs
+++ b/extension/shops/aaaauto.mjs
@@ -48,6 +48,12 @@ export class AAAAuto extends AsyncShop {
     const product = jsonLdProduct();
     if (!product) return null;
 
+    // Angular pushes the new URL before it swaps the detail subtree, so on a client-side
+    // detail -> detail hop the JSON-LD can still describe the previous car. Pairing that
+    // price with this id would persist a wrong price server-side for 24h, so bail and let
+    // the observer retry on the next mutation.
+    if (!product.url?.endsWith(`/${itemId}`)) return null;
+
     const currentPrice = cleanPriceText(product.offers.price);
     if (!currentPrice) return null;
 

--- a/extension/shops/aaaauto.mjs
+++ b/extension/shops/aaaauto.mjs
@@ -46,8 +46,9 @@ export class AAAAuto extends AsyncShop {
 
     // Angular pushes the new URL before swapping the subtree, so after a detail -> detail
     // hop the JSON-LD may still describe the previous car; a mis-paired price is persisted
-    // server-side for 24h. Bail and let the observer retry.
-    if (!product.url?.endsWith(`/${itemId}`)) return null;
+    // server-side for 24h. Compare through the same parser so a trailing slash or a query
+    // on the canonical url cannot silently reject every car. Bail and let the observer retry.
+    if (getItemIdFromUrl(new URL(product.url ?? "", location.href)) !== itemId) return null;
 
     // String(): schema.org allows a numeric price, and cleanPriceText calls .replace on it.
     const currentPrice = cleanPriceText(String(product.offers.price));

--- a/lib/shops.mjs
+++ b/lib/shops.mjs
@@ -39,21 +39,28 @@ const forCampingSk = {
   }
 };
 
+// Redesigned (Angular) aaaauto puts the car id in the path: /detail/{make}/{model}/{id},
+// often followed by a routing hash. Pre-redesign URLs carried it as ?id= and are still
+// stored in price history, so keep reading both.
+const AAAAUTO_DETAIL_PATH = /^\/detail\/[^/]+\/[^/]+\/(\d+)/;
+
+/** @param {URL} url */
+function parseAaaauto(url) {
+  return {
+    itemId: url.searchParams.get("id") ?? url.pathname.match(AAAAUTO_DETAIL_PATH)?.[1] ?? null,
+    get itemUrl() {
+      return this.itemId;
+    }
+  };
+}
+
 const aaaautoCz = {
   name: "AAAAuto.cz",
   currency: "CZK",
   logo: "aaaauto_logo",
   url: "https://www.aaaauto.cz/",
   viewBox: "0 0 99 20",
-  /** @param {URL} url */
-  parse(url) {
-    return {
-      itemId: url.searchParams.get("id"),
-      get itemUrl() {
-        return this.itemId;
-      }
-    };
-  }
+  parse: parseAaaauto
 };
 
 const aaaautoSk = {
@@ -62,15 +69,7 @@ const aaaautoSk = {
   logo: "aaaauto_sk_logo",
   url: "https://www.aaaauto.sk/",
   viewBox: null,
-  /** @param {URL} url */
-  parse(url) {
-    return {
-      itemId: url.searchParams.get("id"),
-      get itemUrl() {
-        return this.itemId;
-      }
-    };
-  }
+  parse: parseAaaauto
 };
 
 const albertCz = {

--- a/lib/shops.mjs
+++ b/lib/shops.mjs
@@ -39,28 +39,22 @@ const forCampingSk = {
   }
 };
 
-// Redesigned (Angular) aaaauto puts the car id in the path: /detail/{make}/{model}/{id},
-// often followed by a routing hash. Pre-redesign URLs carried it as ?id= and are still
-// stored in price history, so keep reading both.
-const AAAAUTO_DETAIL_PATH = /^\/detail\/[^/]+\/[^/]+\/(\d+)/;
-
-/** @param {URL} url */
-function parseAaaauto(url) {
-  return {
-    itemId: url.searchParams.get("id") ?? url.pathname.match(AAAAUTO_DETAIL_PATH)?.[1] ?? null,
-    get itemUrl() {
-      return this.itemId;
-    }
-  };
-}
-
 const aaaautoCz = {
   name: "AAAAuto.cz",
   currency: "CZK",
   logo: "aaaauto_logo",
   url: "https://www.aaaauto.cz/",
   viewBox: "0 0 99 20",
-  parse: parseAaaauto
+  /** @param {URL} url */
+  parse(url) {
+    return {
+      // redesign moved the car id into the path; ?id= urls are still in stored price history
+      itemId: url.searchParams.get("id") ?? url.pathname.match(/^\/detail\/[^/]+\/[^/]+\/(\d+)/)?.[1] ?? null,
+      get itemUrl() {
+        return this.itemId;
+      }
+    };
+  }
 };
 
 const aaaautoSk = {
@@ -69,7 +63,16 @@ const aaaautoSk = {
   logo: "aaaauto_sk_logo",
   url: "https://www.aaaauto.sk/",
   viewBox: null,
-  parse: parseAaaauto
+  /** @param {URL} url */
+  parse(url) {
+    return {
+      // redesign moved the car id into the path; ?id= urls are still in stored price history
+      itemId: url.searchParams.get("id") ?? url.pathname.match(/^\/detail\/[^/]+\/[^/]+\/(\d+)/)?.[1] ?? null,
+      get itemUrl() {
+        return this.itemId;
+      }
+    };
+  }
 };
 
 const albertCz = {

--- a/lib/shops.test.mjs
+++ b/lib/shops.test.mjs
@@ -103,10 +103,19 @@ describe("Shops", () => {
       [
         "https://www.4camping.sk/p/cepice-sensor-merino-wool/#54-58-cm-cerna",
         "cepice-sensor-merino-wool-54-58-cm-cerna"
-      ]
+      ],
+      // Redesigned aaaauto detail URL - the id must match the `slug` the aaaauto-daily actor pushes.
+      ["https://www.aaaauto.cz/detail/skoda/superb/30311332#/ojete-vozy?page=1", "30311332"],
+      ["https://www.aaaauto.sk/detail/volkswagen/tiguan/88613", "88613"],
+      // Pre-redesign URL, still present in stored price history.
+      ["https://www.aaaauto.cz/cz/audi-q7/car.html?id=341760592", "341760592"]
     ].forEach(([itemUrl, expected]) => {
       const slug = itemSlug(itemUrl);
       it(`${itemUrl} should return ${expected}`, () => expect(slug).to.equal(expected));
     });
+
+    // The extension runs on every aaaauto.cz page, so a listing URL must not yield a bogus slug.
+    it("aaaauto listing page should return no slug", () =>
+      expect(itemSlug("https://www.aaaauto.cz/ojete-vozy/?page=1")).to.equal(null));
   });
 });

--- a/scripts/screenshotter.mjs
+++ b/scripts/screenshotter.mjs
@@ -8,7 +8,9 @@ const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const pathToExtension = path.resolve(__dirname, "../extension");
 
 const urlSet = [
-  "https://www.aaaauto.cz/cz/skoda-kodiaq/car.html?id=385818170#category=45&promo=gm",
+  // aaaauto detail URLs carry the car id; a sold car redirects to a listing, so refresh
+  // this from https://www.aaaauto.cz/ojete-vozy/ if the smoke test reports it missing.
+  "https://www.aaaauto.cz/detail/skoda/superb/30311332",
   "https://www.alza.cz/trhakdne",
   "https://www.alza.cz/screenshield-motorola-moto-g7-power-xt1955-4-na-displej-d5600645.htm",
   "https://m.alza.sk/intel-core-i7-9700-d5632692.htm",

--- a/scripts/test-extension.mjs
+++ b/scripts/test-extension.mjs
@@ -7,7 +7,9 @@ const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const pathToExtension = path.resolve(__dirname, "../extension");
 
 const urlSet = [
-  "https://www.aaaauto.cz/cz/skoda-fabia/car.html?id=513181728",
+  // aaaauto detail URLs carry the car id; a sold car redirects to a listing, so refresh
+  // this from https://www.aaaauto.cz/ojete-vozy/ if the smoke test reports it missing.
+  "https://www.aaaauto.cz/detail/skoda/superb/30311332",
   "https://www.alza.cz/hracky/plysovy-mimozemstan-alza-novy-d4536575.htm",
   "https://www.alza.sk/hracky/plysovy-mimozemstan-alza-novy-d4536575.htm",
   "https://www.benu.cz/indulona-original-85ml",


### PR DESCRIPTION
## What & why

Follow-up to #3597. That PR got the actor scraping the redesigned site again, but the
dataset shipped without `slug`, and the redesign broke two more places nobody had
looked at. Addresses #3580.

**PLEASE PAY ATTENTION TO THE [OPEN ISSUES](#open-issues)**

A URL-shape change breaks the price history in three places at once, and all three have
to agree on the same string:

| place | state before this PR |
| --- | --- |
| actor dataset `slug` | absent (dropped in 2021, not restored by the rebuild) |
| `lib/shops.mjs` parse | reads `?id=`, which the redesign removed -> detail API answers **"Missing slug"** |
| `extension/shops/aaaauto.mjs` | reads `?id=` and four selectors that no longer exist -> chart never rendered |

## Changes

**`lib/shops.mjs`** — parse the car id from `/detail/{make}/{model}/{id}` (routing hash
allowed), keeping the `?id=` fallback so URLs already in stored price history still
resolve. Non-detail pages keep returning no slug: the content script runs on every
aaaauto page and must not query a bogus one.

**`actors/aaaauto-daily`** — push `slug` again (the detail id, same as `itemId`).
Inlined rather than imported from `@hlidac-shopu/lib`: the actor image `npm install`s the
**published** `actors-common` -> `lib`, so an imported `itemSlug` would resolve to the
old released parser, not the fix in this PR. `lib/shops.test.mjs` pins that both sides
produce the same string.

**`extension/shops/aaaauto.mjs`** — rebuilt as an `AsyncShop` (the site navigates
client-side). Id via `getItemIdFromUrl`, which shares `lib/shops.mjs` — the extension
bundles the workspace lib, so unlike the actor it tracks the parser automatically. The shop
hands that helper a real `URL` (`new URL(window.location.href)`, as `rohlik.mjs` does) and
checks the canonical url's host itself, so **`extension/helpers.mjs` is untouched** — no
diff against `trunk` on any shared extension internal. Price,
name and image come from the page's schema.org JSON-LD rather than selectors, because the
price markup varies by rollout bucket — `.detail-price-block__price--main` and the legacy
`.price__amount--default` both occur, on both TLDs — while `offers.price` is the cash
price everywhere, the same number the actor stores.

**`actors/AGENT.md`, `actors/NOTES.md`** — the three-way slug contract and the
published-lib trap, written where the next redesign will look.

**`scripts/test-extension.mjs`, `scripts/screenshotter.mjs`** — the aaaauto fixtures still
used `car.html?id=`, which now 302s to a listing, so the smoke test could only ever report
the entry as missing and never exercise the content script.

### Three deliberate calls

- **`originalPrice` stays `null` in the extension.** The redesigned detail page publishes
  no pre-discount price; the second price shown next to the main one (red "Akční cena" on
  the new template, secondary on the legacy one) is the **financed/leasing** price, and
  recording it as `originalPrice` would invent a discount. Consequence worth knowing: for
  cars the *actor* flags as discounted, the extension submits no `originalPrice`, so the
  detail lambda's "Uváděná původní cena" point for today reads as no discount. Same
  behaviour as the other shops that cannot see a former price.
- **`#ng-state` is not used as a source,** although its `car` object is richer (it has
  `oldCash`). It only holds the detail entry when the page was loaded directly; after a
  client-side navigation from a listing — browse, click a car, the common path — the blob
  has no entry for the current car.
- **The stale-JSON-LD guard.** Angular pushes the new URL before it swaps the subtree, so
  on a detail -> detail hop the id and the price can come from different cars, and a
  mis-paired price is persisted server-side for 24 h. The guard compares ids *through*
  `getItemIdFromUrl`, so a trailing slash or a tracking param on the canonical `url`
  cannot silently reject every car. The `url` comes from the page, so the shop checks its
  host before parsing it as ours - an off-host value rejects and never reaches the shared
  helper. A node with no `url` at all passes rather than fails closed - deliberate: every
  stale node the template emits does carry `url`, so strict mode would trade an implausible
  mis-pair for a plausible site-wide outage.

## Testing

### Actor — platform runs

Build `0.0.4` (this branch) on the personal test actor
[`matymar/aaa-prices-scraper`](https://console.apify.com/actors/4JPheFNk7tSfajHw6), through
Apify Proxy. Every dataset was verified item-by-item, paging the whole thing, asserting:
`slug` present, `slug === itemId`, **`itemSlug(itemUrl)` from this branch's `lib/shops.mjs`
returns exactly that slug**, `shopName(itemUrl)` correct, no duplicate slug, and no missing
`itemUrl`/`currentPrice`/`itemName`/`img`.

| what | build | run | dataset | outcome |
| --- | --- | --- | --- | --- |
| FULL CZ | 0.0.4 | [1FQTiHfFNj8U5O0wG](https://console.apify.com/actors/4JPheFNk7tSfajHw6/runs/1FQTiHfFNj8U5O0wG) | [ifTNble8YNDJHOKDJ](https://console.apify.com/storage/datasets/ifTNble8YNDJHOKDJ) | SUCCEEDED, **10 665 items, 0 violations** (305 of 306 pages; one page failed after retries) |
| FULL SK | 0.0.4 | [HeoVTxpaYPqhJpIMg](https://console.apify.com/actors/4JPheFNk7tSfajHw6/runs/HeoVTxpaYPqhJpIMg) | [YqaltxcvYfeK0Unfs](https://console.apify.com/storage/datasets/YqaltxcvYfeK0Unfs) | SUCCEEDED, **4 551 items, 0 violations** |
| FULL SK, all IPs blocked | 0.0.4 | [JlMgOZDnw5mgJqPhb](https://console.apify.com/actors/4JPheFNk7tSfajHw6/runs/JlMgOZDnw5mgJqPhb) | — | SUCCEEDED with **0 items** — see below |

Both full runs need `--timeout 1800`; at the actor's default 300 s cap
([CZ](https://console.apify.com/actors/4JPheFNk7tSfajHw6/runs/mWheouM4TesopeUQ6),
[SK](https://console.apify.com/actors/4JPheFNk7tSfajHw6/runs/l3VUWax3DiGPc3wvY)) the run
TIMED-OUT with a partial dataset.

Discount mapping is exercised by live data: **2 883 of the 10 665 CZ items** and **1 481 of
the 4 551 SK items** are `discounted: true`, every one with `originalPrice` >
`currentPrice`.

No test data reached keboola: the test actor's version sets `DISABLE_KEBOOLA_UPLOAD=1`, so
`uploadToKeboola` returns before calling `blackfriday/uploader` — the CZ run's log contains
no `Keboola` line at all.

### Extension — real bundle against the live site

`yarn test:extension` cannot run here: it launches `headless: false` and this environment
has no display. Instead the **built bundle** (`extension/content.js`, i.e. through
`registerShop`/`AsyncShop`/`getShop`, not a hand-copy of the logic) was run on live pages
with a stubbed `chrome.runtime`, capturing the exact payload it would send. The expected
values come from the actor's own `parseProducts` over the live listing, so both halves are
compared on the same cars in the same minute:

| case | payload the content script sends | actor agrees |
| --- | --- | --- |
| .cz detail, direct load | `itemId 29991488`, `currentPrice "390000"`, name + image | slug `29991488`, `390000` ✅ |
| .sk detail, direct load | `itemId 13830566`, `currentPrice "19500"` | slug `13830566`, `19500` ✅ |
| .cz listing -> detail, client-side nav | `itemId 25250328`, `currentPrice "340000"` | slug `25250328`, `340000` ✅ |
| .cz listing | nothing sent, no anchor matched | — |

The client-side hop lands on `…/detail/skoda/octavia/25250328#/ojete-vozy?page=1`, so the
routing-hash URL and the stale-JSON-LD guard are both exercised on a real page. Injection
point checked visually — a sibling of the price block is squeezed to 271 px by its flex row,
so the anchor is `.detail__header` (present in both buckets) with the pre-redesign 640 px
cap.

Local suites: `yarn test:lib` — 94 passed · `yarn test:actors` — 3 passed ·
`yarn test:api` — 4 passed · `biome check` clean on every file this PR touches (the two
`scripts/*.mjs` import-order warnings are pre-existing; those imports are untouched here).

<a id="open-issues"></a>
**Not tested:**
- The end-to-end chart render. It cannot work until `trunk` deploys: production
  `api.hlidacshopu.cz/v2/detail?url=…/detail/skoda/superb/30311332` still answers
  `{"error":"Missing slug"}`, since the lambda runs the released `lib`. The extension half
  additionally needs an `extension-*` tag release.
- `yarn test:extension` itself. Note `.circleci/config.yml:420` has `test-web-extension`
  commented out, so CI does not cover it either.
- `type=BF` still throws (unchanged from #3597); no Black Friday URL to test against.

## Two things worth separate issues

**1. 0-item runs report SUCCEEDED.** The SK run
[JlMgOZDnw5mgJqPhb](https://console.apify.com/actors/4JPheFNk7tSfajHw6/runs/JlMgOZDnw5mgJqPhb)
reproduced #3580's original symptom on the current build: `590 UPSTREAM502` on every retry
of page 1, **0 items pushed**, run still **SUCCEEDED**. The block is intermittent and
per-IP — the same build scraped 4 551 SK items on a rerun minutes later, and 10 665 CZ items
concurrently. Only the test actor's `DISABLE_KEBOOLA_UPLOAD=1` stopped it there; in
production the run would have gone on to overwrite the keboola table with nothing. A guard
that fails the run when the crawl produced 0 items — before `uploadToKeboola` — turns this
class of outage into an alert. Mechanism is repo-wide, not aaaauto-specific.

**2. `AsyncShop` re-fetches on every mutation when the API returns no data.** Measured
while testing the bundle: **15 `hs-detail` messages within seconds of one client-side
navigation**, and it keeps going. When
`fetchData` returns nothing, `shop.loaded` stays false, so the next DOM mutation re-scrapes
and re-sends — and this site mutates constantly (live chat, gallery, carousels). That is
the state of *every* aaaauto car until price history exists, i.e. immediately after deploy
for all ~11 k cars. Pre-existing in `extension/shops/shop.mjs` and shared by the other
`AsyncShop` sites, so deliberately not changed here.

