### PR TITLE
fix(hornbach-daily): repair zero-item run — Fastly challenge bypass + crawlee pin

### DIFF
--- a/actors/hornbach-daily/Dockerfile
+++ b/actors/hornbach-daily/Dockerfile
@@ -1,8 +1,13 @@
-FROM apify/actor-node:24
+FROM apify/actor-node-playwright-chrome:24
 
 COPY package.json ./
 
 RUN npm --quiet set progress=false \
- && npm install --only=prod --no-optional
+ && npm install --omit=dev --omit=optional --fund=false --audit=false --save=false
+
+# Pre-download the cloakbrowser stealth-Chromium binary (~200 MB) during the
+# image build so the first actor run doesn't pay the download cost. The
+# library caches the binary under $HOME/.cache/cloakbrowser by default.
+RUN node -e "import('cloakbrowser').then(async ({ launch }) => { const b = await launch({ headless: true }); await b.close(); }).catch(e => { console.error(e); process.exit(1); })"
 
 COPY . ./

--- a/actors/hornbach-daily/README.md
+++ b/actors/hornbach-daily/README.md
@@ -1,13 +1,136 @@
 # hornbach-daily
 
-Categories URL is https://www.hornbach.cz/c/
+Scrapes hornbach.cz / hornbach.sk category listings.
 
-Pagination based on total product count divided by 72.
+Categories start at https://www.hornbach.cz/c/ and are walked depth-first:
+`TOP_CATEGORIES` → `SUB_CATEGORIES` (recursive) → `CAT_PRODUCTS`. A category page
+with no further subcategory cards is a leaf, and product listings are then queued
+for the leaf and every category above it in the crumb trail.
+
+Products and the page count both come from the Apollo cache embedded in the
+listing HTML (`window.__APOLLO_STATE__` → `ROOT_QUERY.categoryListing(...)`),
+not from the DOM. Page size is 72, but `listing.pageCount` is authoritative —
+don't reintroduce a hardcoded divisor.
 
 ## Actor's INPUT
 
 ```json
 {
-  "country": "CZ" || "SK"
+  "country": "CZ",
+  "type": "FULL",
+  "debug": false,
+  "maxRequestRetries": 8,
+  "maxRequestsPerMinute": 600,
+  "maxConcurrency": 10
 }
 ```
+
+```text
+"country": "CZ" || "SK"
+"type":    "FULL" || "TEST"
+```
+
+`TEST` keeps only the first 2 requests at each level, which is enough to exercise
+the whole pipeline in about 30 seconds.
+
+## Actor's item example OUTPUT
+
+```json
+{
+  "itemId": "10702323",
+  "itemName": "Barva na zeď Hornbach Sněhobílá profesionální bez konzervantů 16 kg",
+  "itemUrl": "https://www.hornbach.cz/p/barva-na-zed-hornbach-snehobila-profesionalni-bez-konzervantu-16-kg/10702323/",
+  "img": "https://media.hornbach.cz/hb/packshot/as.71177684.jpg?dvid=7",
+  "currentPrice": 1199,
+  "currentUnitPrice": 74.94,
+  "category": {
+    "link": "https://www.hornbach.cz/c/barvy-tapety-a-oblozeni-sten/barvy-laky/S12032/",
+    "title": "Barvy, laky"
+  },
+  "currency": "CZK"
+}
+```
+
+`currentUnitPrice` is `""` for products sold per piece — roughly a third of items.
+Because ancestor categories are scraped as well as leaves, a product legitimately
+appears once per category it belongs to.
+
+## Fastly bot protection
+
+Hornbach sits behind Fastly Bot Management. A request it doesn't like gets
+**HTTP 200 with a ~3 KB "Client Challenge" stub** that loads
+`/_fs-ch-<token>/script.js` instead of the page. Nothing fails, so the breakage
+is silent: in August 2026 the actor "succeeded" with `requestsFailed: 0` while
+scraping 0 items, because the start page matched no selectors and the queue
+drained. **A run reporting 0 items and 0 failures is this, not a selector break.**
+
+Measured pass rates for a Chrome-TLS HTTP client holding no challenge cookie:
+
+| Origin | Passes |
+| --- | --- |
+| Apify residential CZ (`CZECH_LUMINATI`) | 0/40 |
+| Apify datacenter (`SHADER`, `GERMANY`) | 0/8 |
+| Consumer IP | ~60%, intermittent |
+
+So **adding a proxy does not help** — every Apify proxy IP is challenged, which
+is why this actor deliberately runs without `proxyConfiguration`. Proxy
+*tunnelling* is not the trigger either: the same client through a local CONNECT
+proxy on a consumer IP passes at the unproxied rate. It is IP reputation.
+
+The fix is the two-phase split that `datart-daily` (F5) and `lidl-daily` (Myra)
+already use:
+
+1. **Solver** — cloakbrowser executes the sensor script and clears the challenge
+   in ~2 s, yielding a long-lived `_fs_ch_cp_` ("challenge passed") cookie.
+2. **Executor** — `impit` with a Chrome TLS fingerprint replays that cookie.
+   Fastly fingerprints the handshake on *every* request, so node fetch /
+   got-scraping / curl-OpenSSL stay challenged even holding a valid cookie.
+
+Verified 10/10 on an IP where impit alone was blocked 100% of the time.
+
+### Two traps worth keeping in mind
+
+**A challenged client never recovers.** It keeps the challenge's own
+`_fs_ch_st_` cookie (10 s TTL, refreshed on every challenged response) and stays
+challenged indefinitely — measured **0/10** when retrying on the same `Impit`
+instance versus **9/10** when the instance is discarded on the first challenge
+and reused while it keeps working. A single challenge would otherwise deadlock
+the whole crawl. Hence: a challenge rotates the executor client, and
+`_fs_ch_st_` is stripped from the solved cookies rather than replayed all run.
+
+**A solve does not always earn a pass cookie, and that must force a re-solve.**
+If Fastly happens not to be challenging at the moment the browser runs, the
+solver clears the page and returns only the `hb*` session cookies — the log says
+`IP not challenged`. The executor is then unprotected, and when Fastly starts
+challenging it, *retries alone can never recover*: only a real browser solve can.
+An earlier version of this actor throttled re-solves on the theory that a
+challenge right after a fresh solve was random noise. That starved the crawl —
+one test run logged 91 challenges, 0 re-solves and 0 items. So every challenged
+response now triggers a re-solve, with a mutex (not a cooldown) keeping
+concurrent workers from stampeding cloakbrowser. This matches `datart-daily` and
+`lidl-daily`, which re-solve on every block for the same reason.
+
+## Notes for maintainers
+
+- `maxRequestRetries` is passed to `getInput()` as an **override**, because
+  `getInput()` itself defaults it to 3 — a destructuring default can never win
+  against that. (`albert/main.js` has the same dead `= 5` default.)
+- Enqueueing goes through `crawler.requestQueue.addRequests(...)` like the other
+  14 actors that do it, rather than an explicitly opened queue. `Actor.openRequestQueue()`
+  returns a V2 queue in this Crawlee version and every actor in the repo runs on
+  V2, `forefront` included, so there is no reason to special-case this one.
+- The Dockerfile needs the `playwright-chrome` base image, and
+  `impit-linux-x64-gnu` stays a direct dependency so impit's native binary
+  survives `npm install --omit=optional`.
+- `@crawlee/{core,types,utils}` are pinned to 3.17.0 as direct dependencies to
+  match `@crawlee/basic`. **Don't drop these when bumping deps.** `@crawlee/basic`
+  requires `@crawlee/core` at exactly its own version while `apify` requires
+  `^3.14.1`; the Dockerfile installs from `package.json` with npm and no
+  lockfile, so without the pins npm keeps the base image's newer `@crawlee/core`
+  and nests an older copy under `@crawlee/basic`, and `Actor.init` throws
+  `Detected incompatible Crawlee version` before the first request. Pin all
+  three — pinning only `core` still leaves `types`/`utils` split. Not via npm
+  `overrides`: the repo is yarn-managed and reviewers reject those.
+- Category names must be read off each slider card (`link.querySelector("p")`),
+  never via `document.querySelector` — the latter labels every category on a page
+  with the first card's name.

--- a/actors/hornbach-daily/main.js
+++ b/actors/hornbach-daily/main.js
@@ -1,4 +1,4 @@
-import { HttpCrawler } from "@crawlee/http";
+import { BasicCrawler } from "@crawlee/basic";
 import { withPersistedStats } from "@hckr_/apify-persistent-stats";
 import { ActorType } from "@hlidac-shopu/actors-common/actor-type.js";
 import { getInput, restPageUrls } from "@hlidac-shopu/actors-common/crawler.js";
@@ -7,6 +7,8 @@ import { uploadToKeboola } from "@hlidac-shopu/actors-common/keboola.js";
 import rollbar from "@hlidac-shopu/actors-common/rollbar.js";
 import { shopName } from "@hlidac-shopu/lib/shops.mjs";
 import { Actor, Dataset, LogLevel, log } from "apify";
+import { launchContext as launchCloakContext } from "cloakbrowser";
+import { Impit } from "impit";
 
 /** @enum {string} */
 const Country = {
@@ -20,6 +22,11 @@ const Currency = {
   SK: "EUR"
 };
 
+const Locale = {
+  CZ: { locale: "cs-CZ", timezoneId: "Europe/Prague", acceptLanguage: "cs-CZ,cs;q=0.9,en;q=0.8" },
+  SK: { locale: "sk-SK", timezoneId: "Europe/Bratislava", acceptLanguage: "sk-SK,sk;q=0.9,en;q=0.8" }
+};
+
 /** @enum {string} */
 const Labels = {
   TOP_CATEGORIES: "TOP_CATEGORIES",
@@ -31,8 +38,7 @@ const Labels = {
 const Selectors = {
   TOP_CATEGORIES: '[data-testid="product-category"] h2 a',
   SUB_CATEGORIES: '[data-testid="categories-slider"] [data-testid="slider-card"] a',
-  CATEGORY_NAME: '[data-testid="categories-slider"] [data-testid="slider-card"] a p',
-  TOTAL_PRODUCTS_COUNT: '[data-testid="result-count"]'
+  CATEGORY_NAME: "p"
 };
 
 /**
@@ -41,6 +47,83 @@ const Selectors = {
  */
 function completeUrl(country, path) {
   return new URL(path, `https://www.hornbach.${country.toLowerCase()}`).href;
+}
+
+// Fastly Bot Management answers non-consumer IPs with a 200 + JS challenge stub
+// instead of the page, so the crawl needs a browser-solved cookie and a Chrome
+// TLS fingerprint. See README.md ("Fastly bot protection") for the measurements
+// behind this design; same solver/executor split as datart-daily and lidl-daily.
+
+function isChallenge(body) {
+  return body.includes("Client Challenge") || body.includes("/_fs-ch-");
+}
+
+/**
+ * Launch cloakbrowser, let it clear the Fastly challenge, return the cookie jar.
+ * @param {string} rootUrl
+ * @param {{locale: string, timezoneId: string}} locale
+ * @returns {Promise<Record<string, string>>}
+ */
+async function solveChallenge(rootUrl, locale) {
+  log.info("Solver: launching cloakbrowser to clear the Fastly client challenge…");
+  const ctx = await launchCloakContext({
+    headless: true,
+    locale: locale.locale,
+    timezoneId: locale.timezoneId
+  });
+  try {
+    const page = await ctx.newPage();
+    await page.goto(`${rootUrl}/c/`, { waitUntil: "domcontentloaded", timeout: 60000 });
+
+    const deadline = Date.now() + 60000;
+    while (Date.now() < deadline) {
+      try {
+        if (!isChallenge(await page.content())) {
+          const jar = await ctx.cookies(rootUrl);
+          const passCookie = jar.find(c => c.name.startsWith("_fs_ch_cp_"));
+          log.info(
+            `Solver: challenge cleared (${jar.length} cookies${passCookie ? ", _fs_ch_cp_ present" : ", IP not challenged"})`
+          );
+          // Resending _fs_ch_st_ (the challenge's own 10 s state cookie) is what
+          // keeps a client stuck in the challenge — drop it, keep _fs_ch_cp_ + hb*.
+          return Object.fromEntries(jar.filter(c => !c.name.startsWith("_fs_ch_st_")).map(c => [c.name, c.value]));
+        }
+      } catch {
+        // a content read can race the challenge's own navigation — keep polling
+      }
+      await page.waitForTimeout(1000);
+    }
+    throw new Error("Solver: timed out waiting for the Fastly challenge to clear");
+  } finally {
+    await ctx.close();
+  }
+}
+
+/** A fresh executor client, i.e. an empty cookie jar behind a Chrome TLS fingerprint. */
+function newExecutor() {
+  return new Impit({ browser: "chrome", ignoreTlsErrors: true });
+}
+
+/**
+ * @param {Impit} impit
+ * @param {Record<string, string>} cookies
+ * @param {string} url
+ * @param {string} acceptLanguage
+ */
+async function executorFetch(impit, cookies, url, acceptLanguage) {
+  const cookieHeader = Object.entries(cookies)
+    .map(([k, v]) => `${k}=${v}`)
+    .join("; ");
+  const res = await impit.fetch(url, {
+    headers: {
+      Cookie: cookieHeader,
+      Accept:
+        "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+      "Accept-Language": acceptLanguage,
+      "Upgrade-Insecure-Requests": "1"
+    }
+  });
+  return { status: res.status, body: await res.text() };
 }
 
 function topCategoriesRequests({ document, country }) {
@@ -63,7 +146,10 @@ function subCategoriesRequests({ document, country, request, stats }) {
   return links.map(link => {
     const crumb = {
       link: completeUrl(country, link.getAttribute("href")),
-      title: document.querySelector(Selectors.CATEGORY_NAME).innerText.trim()
+      // The name lives in the card this link wraps — reading it off the
+      // document would label every category on the page after the first one
+      // with the first card's name.
+      title: link.querySelector(Selectors.CATEGORY_NAME)?.innerText?.trim()
     };
     stats.inc("categories");
     log.debug(`Scraped category "${crumb.title}"`);
@@ -78,7 +164,7 @@ function subCategoriesRequests({ document, country, request, stats }) {
 }
 
 function catProductsFromSubCategoriesRequests({ request }) {
-  const categoriesFromBottomToTop = request.userData.crumbs.reverse();
+  const categoriesFromBottomToTop = [...request.userData.crumbs].reverse();
   log.debug(`Hit rock bottom at ${categoriesFromBottomToTop.length}. level`);
 
   return categoriesFromBottomToTop.map(category => {
@@ -95,56 +181,63 @@ function catProductsFromSubCategoriesRequests({ request }) {
 }
 
 /**
- * @param {string} str
+ * Hornbach renders listings from an Apollo cache embedded in the page, which
+ * carries the products and the page count that the DOM only shows as prose.
+ * @param {ReturnType<typeof parseHTML>["document"]} document
+ * @param {string} url
  */
-function parseCategoryProductsCount(str) {
-  if (!str) return 0;
-  const match = str.match(/\d+/g);
-  return match ? Number(match[0]) : 0;
+function parseCategoryListing(document, url) {
+  const script = Array.from(document.querySelectorAll("script")).find(s => s.innerText.includes("__APOLLO_STATE__"));
+  if (!script) {
+    log.error(`No Apollo state found in ${url}`);
+    return null;
+  }
+  // Anchor on the assignment rather than the first brace in the tag: the same
+  // script also assigns __ARTICLE_LISTING_BUGSNAG_CONF after the state object.
+  const text = script.innerText;
+  const bugsnagAt = text.indexOf("window.__ARTICLE_LISTING_BUGSNAG_CONF");
+  const stateOnly = bugsnagAt === -1 ? text : text.slice(0, bugsnagAt);
+  const start = stateOnly.indexOf("{", stateOnly.indexOf("__APOLLO_STATE__"));
+  const end = stateOnly.lastIndexOf("}") + 1;
+  if (start === -1 || end <= start) {
+    log.error(`Could not locate the Apollo state object in ${url}`);
+    return null;
+  }
+  const json = stateOnly.slice(start, end);
+  let data;
+  try {
+    data = JSON.parse(json);
+  } catch (e) {
+    log.error(`Failed to parse Apollo state in ${url}: ${e instanceof Error ? e.message : e}`);
+    return null;
+  }
+  const key = Object.keys(data.ROOT_QUERY ?? {}).find(k => k.includes("categoryListing"));
+  if (!key) {
+    log.error(`No categoryListing in Apollo state of ${url}`);
+    return null;
+  }
+  return data.ROOT_QUERY[key];
 }
 
-function catProductsRequests({ document, request }) {
-  const categoryProductsCountNode = document.querySelector(Selectors.TOTAL_PRODUCTS_COUNT);
-  if (!categoryProductsCountNode) {
-    log.error(`No products count node found in ${request.url}`);
-    return;
-  }
-  const categoryProductsCount = parseCategoryProductsCount(categoryProductsCountNode?.textContent);
+function catProductsRequests({ listing, request }) {
+  if (request.userData.page !== 1) return [];
 
   const { category } = request.userData;
+  const pagesCount = Number(listing.pageCount ?? 0);
+  log.debug(`Category ${category.link} has ${pagesCount} pages`);
 
-  log.debug(`Scraping ${request.userData.page}. Page on ${request.url}`);
-  if (request.userData.page === 1) {
-    log.debug(`Category URL is ${category.link}`);
-    const pagesCount = Math.ceil(categoryProductsCount / 72);
-    log.debug(`Category has ${pagesCount} pages`);
-
-    return restPageUrls(pagesCount, page => ({
-      url: `${category.link}?page=${page}`,
-      userData: {
-        label: Labels.CAT_PRODUCTS,
-        category,
-        page
-      }
-    }));
-  } else {
-    return [];
-  }
+  return restPageUrls(pagesCount, page => ({
+    url: `${category.link}?page=${page}`,
+    userData: {
+      label: Labels.CAT_PRODUCTS,
+      category,
+      page
+    }
+  }));
 }
 
-function extractProducts({ document, stats, country, request }) {
-  const allDocumentScripts = Array.from(document.querySelectorAll("script"));
-  const string = allDocumentScripts
-    .find(script => script.innerText.includes("__APOLLO_STATE__"))
-    .innerText.split("window.__ARTICLE_LISTING_BUGSNAG_CONF")[0];
-  const startIndex = string.indexOf("{");
-  const endIndex = string.lastIndexOf("}") + 1;
-
-  const jsonString = string.split("window.__ARTICLE_LISTING_BUGSNAG_CONF")[0].substring(startIndex, endIndex);
-  const data = JSON.parse(jsonString);
-  const key = Object.keys(data.ROOT_QUERY).find(key => key.includes("categoryListing"));
-
-  const productsInfoArray = data.ROOT_QUERY[key].itemList.filter(item => item.abstractProductId);
+function extractProducts({ listing, stats, country, request }) {
+  const productsInfoArray = (listing.itemList ?? []).filter(item => item?.abstractProductId);
 
   return productsInfoArray.map(item => {
     const currency = Currency[country.toUpperCase()];
@@ -175,10 +268,18 @@ async function main() {
   const stats = await withPersistedStats({
     categories: 0,
     items: 0,
+    blocked: 0,
     failed: 0
   });
 
-  const { type = ActorType.Full, country = Country.CZ, debug = false } = (await getInput()) ?? {};
+  const {
+    type = ActorType.Full,
+    country = Country.CZ,
+    debug = false,
+    maxRequestRetries,
+    maxRequestsPerMinute = 600,
+    maxConcurrency = 10
+  } = await getInput({ maxRequestRetries: 8 });
 
   if (debug) {
     log.setLevel(LogLevel.DEBUG);
@@ -191,12 +292,62 @@ async function main() {
     return;
   }
 
-  const crawler = new HttpCrawler({
-    maxRequestsPerMinute: 600,
-    async requestHandler({ request, crawler, body, log }) {
+  const rootUrl = `https://www.hornbach.${country.toLowerCase()}`;
+  const locale = Locale[country.toUpperCase()] ?? Locale.CZ;
+
+  // Phase 1 — Solver: earn a Fastly challenge-passed session.
+  let cookies = await solveChallenge(rootUrl, locale);
+
+  // Phase 2 — Executor: impit with a Chrome TLS fingerprint.
+  log.info("Executor: initializing impit (chrome TLS)");
+  let impit = newExecutor();
+
+  // Any challenged response means re-solve: a solver run on an IP Fastly happens
+  // not to be challenging clears the page without a pass cookie, and then only a
+  // real solve can protect the executor — retries alone cannot. A mutex
+  // (in-flight promise) keeps concurrent workers from stampeding cloakbrowser.
+  /** @type {Promise<void> | null} */
+  let solvePromise = null;
+  /** @param {string} reason */
+  async function triggerResolve(reason) {
+    if (solvePromise) return solvePromise;
+    solvePromise = (async () => {
+      try {
+        log.warning(`Fastly re-solve triggered: ${reason}`);
+        cookies = await solveChallenge(rootUrl, locale);
+      } finally {
+        solvePromise = null;
+      }
+    })();
+    return solvePromise;
+  }
+
+  const crawler = new BasicCrawler({
+    maxRequestRetries,
+    maxRequestsPerMinute,
+    maxConcurrency,
+    async requestHandler({ request, crawler, log }) {
+      if (solvePromise) await solvePromise;
+
       const label = request.userData.label;
-      log.info(`Processing ${request.url} (${label})`);
-      const { document } = parseHTML(body.toString());
+      log.debug(`Processing ${request.url} (${label})`);
+
+      const client = impit;
+      const { status, body } = await executorFetch(client, cookies, request.url, locale.acceptLanguage);
+
+      if (isChallenge(body)) {
+        stats.inc("blocked");
+        // Retire the poisoned jar, but only once per client — the other workers
+        // holding the same instance would otherwise each rotate it again.
+        if (client === impit) impit = newExecutor();
+        await triggerResolve(`client challenge on ${request.url} (status=${status}, ${body.length}b)`);
+        throw new Error("Fastly client challenge, retrying on a fresh session");
+      }
+      if (status !== 200) {
+        throw new Error(`Unexpected status ${status} for ${request.url}`);
+      }
+
+      const { document } = parseHTML(body);
 
       switch (label) {
         case Labels.TOP_CATEGORIES:
@@ -227,9 +378,11 @@ async function main() {
           break;
         case Labels.CAT_PRODUCTS:
           {
-            const requests = catProductsRequests({ document, request });
+            const listing = parseCategoryListing(document, request.url);
+            if (!listing) return;
+            const requests = catProductsRequests({ listing, request });
             await crawler.requestQueue.addRequests(filterTestRequests({ requests, type }));
-            const products = extractProducts({ document, stats, country, request });
+            const products = extractProducts({ listing, stats, country, request });
             await Dataset.pushData(products);
           }
           break;
@@ -243,7 +396,7 @@ async function main() {
     }
   });
 
-  const startUrl = completeUrl(country, "/c/");
+  const startUrl = `${rootUrl}/c/`;
   await crawler.run([
     {
       url: startUrl,

--- a/actors/hornbach-daily/package.json
+++ b/actors/hornbach-daily/package.json
@@ -6,10 +6,17 @@
   "license": "EUPL-1.2",
   "type": "module",
   "dependencies": {
-    "@crawlee/http": "3.17.0",
+    "@crawlee/basic": "3.17.0",
+    "@crawlee/core": "3.17.0",
+    "@crawlee/types": "3.17.0",
+    "@crawlee/utils": "3.17.0",
     "@hckr_/apify-persistent-stats": "1.0.4",
     "@hlidac-shopu/actors-common": "3.2.6",
-    "apify": "3.7.2"
+    "apify": "3.7.2",
+    "cloakbrowser": "0.4.2",
+    "impit": "0.14.2",
+    "impit-linux-x64-gnu": "0.14.2",
+    "playwright-core": "1.61.0"
   },
   "devDependencies": {
     "@types/node": "24.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4317,12 +4317,19 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@hlidac-shopu/hornbach-daily@workspace:actors/hornbach-daily"
   dependencies:
-    "@crawlee/http": "npm:3.17.0"
+    "@crawlee/basic": "npm:3.17.0"
+    "@crawlee/core": "npm:3.17.0"
+    "@crawlee/types": "npm:3.17.0"
+    "@crawlee/utils": "npm:3.17.0"
     "@hckr_/apify-persistent-stats": "npm:1.0.4"
     "@hlidac-shopu/actors-common": "npm:3.2.6"
     "@types/node": "npm:24.13.2"
     apify: "npm:3.7.2"
     apify-cli: "npm:1.6.2"
+    cloakbrowser: "npm:0.4.2"
+    impit: "npm:0.14.2"
+    impit-linux-x64-gnu: "npm:0.14.2"
+    playwright-core: "npm:1.61.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Fixes #3583.

Hornbach sits behind Fastly Bot Management. Any request it doesn't like is answered with **HTTP 200 and a ~3 KB "Client Challenge" stub** that loads `/_fs-ch-<token>/script.js` instead of the page. Nothing 4xx's and nothing
throws, so the actor "succeeded" with `requestsFailed: 0` while scraping 0 items — the start page matched no selectors and the queue drained immediately. The old `HttpCrawler` (got-scraping) had been parsing the challenge stub.

Measured pass rates for a Chrome-TLS HTTP client holding no challenge cookie: 0/40 from Apify residential CZ (`CZECH_LUMINATI`), 0/8 from Apify datacenter (`SHADER`, `GERMANY`), ~60% and intermittent from a consumer IP. It is IP reputation, so **adding a proxy does not help** and this actor deliberately runs without `proxyConfiguration`. Details and measurements in the actor README.

## Bot protection handling

Same two-phase solver/executor split as `datart-daily` (F5) and `lidl-daily` (Myra), replacing `HttpCrawler` with `BasicCrawler`:

* **Solver** (`solveChallenge`): `cloakbrowser` navigates `/c/`, lets the Fastly sensor script run, and polls until the page is no longer the challenge stub — ~2 s — yielding a long-lived `_fs_ch_cp_` ("challenge passed") cookie.
* **Executor** (`executorFetch`): `impit` impersonates Chrome's TLS handshake from Node. Fastly fingerprints the handshake on *every* request, so node fetch / got-scraping / curl-OpenSSL stay challenged even holding a valid cookie. Verified 10/10 on an IP where impit alone was blocked 100% of the time.
* **Client rotation on challenge**: a challenged `Impit` keeps the challenge's own `_fs_ch_st_` cookie (10 s TTL, refreshed on every challenged response) and is then challenged indefinitely — 0/10 recovery when retrying on the same instance versus 9/10 when it is discarded on first challenge and reused while it keeps working. One challenge would otherwise deadlock the whole crawl. `_fs_ch_st_` is also stripped from the solved cookies rather than replayed.
* **Mutex'd re-solve**: every challenged response triggers a re-solve, with a single in-flight `solvePromise` serialising them. A solver run on an IP Fastly happens not to be challenging returns no pass cookie (`IP not challenged`), leaving the executor unprotected — and retries alone cannot recover from that, only a real solve can.
* Dockerfile switches from `apify/actor-node:24` to `apify/actor-node-playwright-chrome:24` because `cloakbrowser` and `impit-linux-x64-gnu` ship glibc-only prebuilds, and pre-downloads the ~200 MB stealth Chromium at image build time.

## Crawlee version pin

`@crawlee/basic@3.17.0` requires `@crawlee/core` at exactly 3.17.0, while `apify@3.7.2` requires `^3.14.1` — currently 3.18.1. The Dockerfile copies only `package.json` and runs npm with no lockfile, so npm keeps the base image's preinstalled `@crawlee/core@3.18.1` at top level and nests a second 3.17.0 copy under `@crawlee/basic`; `Actor.init` then throws `Detected incompatible Crawlee version` before the first request. Note this needs the preinstalled copy — a fresh `npm install` from this `package.json` alone resolves cleanly to a single 3.17.0, so it does not reproduce outside the image.

Pinned `@crawlee/{core,types,utils}` to 3.17.0 as direct dependencies — the same direct-pin approach `tsbohemia-daily` uses for `@crawlee/core`, rather than npm `overrides` (the repo is yarn-managed). Pinning only `core` still leaves `types`/`utils` split across versions.

## Data fixes

* **Category names** were read with `document.querySelector(...)`, so every category on a page after the first was labelled with the *first* slider card's name. Now read from the card each link wraps: across the full run below, 2,591 category links yield 2,588 distinct titles, the 3 collisions being genuinely same-named categories under different parents (e.g. "Poštovní schránky").
* **Pagination** used `Math.ceil(resultCount / 72)` parsed out of the prose `"2088 výsledků"` result-count node. The embedded Apollo cache already carries `listing.pageCount`, so the fragile selector and the hardcoded page size are both gone. Products and page count now come from one parse of `ROOT_QUERY.categoryListing(...)`, anchored on the `__APOLLO_STATE__` assignment rather than the first brace in the script tag.
* Per-request `Processing …` logging demoted to `debug` (a full run is ~8900 requests); run totals are already in stats.

## Verification runs

On `janrezek/hornbach-cz`, built from this branch with the actor's own root Dockerfile.

Full run (FULL/CZ, 4 GB): **331,052 items across 117,211 distinct products** and 2,591 categories, **8897/8897 requests, 0 failed, 0 blocked, 0 retries**, 20.6 min, peak memory 885 MB of 4096. Zero defects across all 331k rows — no null `itemId`/`itemName`/`itemUrl`/`img`/`currency`/`category.title`, every `currentPrice` a positive number (0.18–462,250 CZK), every URL on `www.hornbach.cz`. **One solve held the entire run: 0 re-solves, 0 challenges after the initial `_fs_ch_cp_`.** https://console.apify.com/actors/LXNxREWPtAh3YCGfP/runs/uswo4qagDnYucPsUo#output

Test run (TEST/SK): **2545 items**, 91 categories, 74/74 requests, 0 failed, 0 bad rows, currency `EUR`, URLs on `www.hornbach.sk`. https://console.apify.com/actors/LXNxREWPtAh3YCGfP/runs/C15OtRMGyhYL80kFp#output

The Keboola upload is skipped on the test account (`DISABLE_KEBOOLA_UPLOAD=1`); `blackfriday/uploader` is not reachable from a personal account, so that branch can only be exercised on the org account.
