### PR TITLE
perf(obi): raise the request rate cap from 600 to 1200 per minute

### DIFF
--- a/actors/obi-daily/main.js
+++ b/actors/obi-daily/main.js
@@ -188,7 +188,7 @@ async function main() {
   });
 
   const crawler = new HttpCrawler({
-    maxRequestsPerMinute: 600,
+    maxRequestsPerMinute: 1200,
     requestHandlerTimeoutSecs: 45,
     // robots.txt is served as text/plain, which HttpCrawler rejects by default
     additionalMimeTypes: ["text/plain"],


### PR DESCRIPTION
Follow-up to #3594, from Zuzka asking why the obi run takes so long.

## Problem

The crawler throttles itself well below what obi serves. A product page answers in about **0.3 s** direct, but the pool settles at 97 concurrent requests against `maxRequestsPerMinute: 600`, so each slot spends roughly 10 s waiting on the rate limiter rather than on the site.

## Measured

Platform runs, 20 minutes each, same input, 8 GB memory:

| cap | requests/min | concurrency | blocked |
|---|---|---|---|
| 600 | 456 | 97 | 0 |
| 3000 | 721 | 191 | 0 |

No 403 and no 429 in either run. The only failures were nine proxy `ECONNRESET`s in a single burst, all retried successfully.

Derived full crawl: about 4.6 h before, about 2.9 h after.

## Why 1200 and not more

The pool tops out near 721 requests/min regardless, so a higher cap buys nothing. Per request latency also grows as concurrency rises (12 s to 16 s), which suggests obi or the proxy becomes the limit near 12 requests/second. 1200 leaves the cap non-binding without leaning harder on the site.

## Worth knowing separately

Two things this does not address:

- Memory. Peak usage is **2117 MB**, above the 2048 MB the actor was set to, so it was running at its ceiling. 8192 MB measured 38% faster than 4096 (330 to 456 requests/min) because memory is how CPU is allocated.
- Request count. The run is about 126000 requests, of which roughly 121000 are product detail pages. The category listings already carry id, name, url, image and price, the price in a `data-csscontent` attribute. Parsing those instead would need about 4500 requests. I checked 8 tiles against their detail pages and 7 matched exactly, the eighth being a per unit price my selector missed. The catch is that `originalPrice` and `discounted` exist only on detail pages, so that change needs a decision rather than just a patch. Happy to open it separately if wanted.
