### PR TITLE
feat(obi): read products from category listings instead of detail pages

### DIFF
--- a/actors/obi-daily/main.js
+++ b/actors/obi-daily/main.js
@@ -16,7 +16,6 @@ const Labels = {
   SitemapIndex: "SITEMAP_INDEX",
   CategorySitemap: "CATEGORY_SITEMAP",
   List: "LIST",
-  Detail: "DETAIL",
   SubCat: "SUBCAT"
 };
 
@@ -76,89 +75,65 @@ function pagesRequests({ document, url }) {
     : [];
 }
 
-function listUrls({ request, document, processedIds }) {
-  return document
-    .querySelectorAll("li.product > a")
-    .filter(a => a.getAttribute("data-ui-name"))
-    .map(a => a.href)
-    .filter(url => !processedIds.has(url))
-    .map(url => {
-      processedIds.add(url);
-      return new URL(url, request.url).href;
-    });
-}
+/**
+ * Category listings carry every field the dataset needs, so the per product
+ * detail page is not fetched. The price sits in a `data-csscontent` attribute
+ * rather than in text, because OBI renders it through CSS. Discounted tiles use
+ * a different block (`strike-price-*`) that also carries the price before the
+ * cut.
+ *
+ * @param {{ document: Document, url: string, country: string, processedIds: Set<string> }} options
+ */
+function extractProducts({ document, url, country, processedIds }) {
+  const category = listingCategory(document);
+  const currency = country === "sk" ? "EUR" : "CZK";
+  const products = [];
+  for (const tile of document.querySelectorAll("li.product")) {
+    const link = tile.querySelector('a[href*="/p/"]');
+    const href = link?.getAttribute("href");
+    if (!href) continue;
+    const itemId = href.match(/\/p\/(\d+)/)?.[1];
+    if (!itemId || processedIds.has(itemId)) continue;
 
-function extractProduct({ url, document }) {
-  const itemId = document.querySelector('input[name="code"]').getAttribute("value").trim();
-  let currency = document.querySelector('meta[itemprop="priceCurrency"]')?.getAttribute("content");
-  if (!currency) return;
-  if (currency === "SKK") {
-    currency = "EUR";
+    const discountedPrice = tile.querySelector(".strike-price-current")?.getAttribute("data-csscontent");
+    const beforeDiscount = tile.querySelector(".strike-price-old")?.textContent;
+    const plainPrice = tile.querySelector(".price-new")?.getAttribute("data-csscontent");
+
+    const currentPrice = cleanPrice(discountedPrice ?? plainPrice);
+    if (!currentPrice) continue;
+    const originalPrice = beforeDiscount ? cleanPrice(beforeDiscount) : null;
+
+    processedIds.add(itemId);
+    products.push({
+      itemId,
+      itemUrl: new URL(href, url).href,
+      itemName: (link.getAttribute("title") ?? "").trim(),
+      img: tile.querySelector("img.image")?.getAttribute("src") ?? null,
+      currency,
+      currentPrice,
+      originalPrice,
+      discounted: Boolean(originalPrice && originalPrice > currentPrice),
+      // Availability is not exposed on the listing, and was hardcoded before.
+      inStock: true,
+      category
+    });
   }
-  const discountedPrice = document.querySelector(".buybox .saving + del")?.innerText;
-  const originalPrice = discountedPrice ? cleanPrice(discountedPrice) : null;
-  let img = document.querySelector(".ads-slider__link").href;
-  if (!img) {
-    img = document.querySelector(".ads-slider__image").getAttribute("data-src");
-  }
-  return {
-    itemUrl: url,
-    itemName: document.querySelector(".overview__description >.overview__heading").innerText.trim(),
-    itemId,
-    currency,
-    currentPrice: cleanPrice(document.querySelector('[data-ui-name="ads.price.strong"]').innerText),
-    discounted: Boolean(discountedPrice),
-    originalPrice,
-    // It looks like the inStock is not available on the product page, so we are not using it anymore.
-    inStock: true, // Boolean(document.querySelector("div.marg_b5").innerText.match(/(\d+)/)),
-    img: `https:${img}`,
-    category: document
-      .querySelectorAll('a[class*="normal"][wt_name*="breadcrumb.level"]')
-      .map(a => a.innerText)
-      .join("/")
-  };
+  return products;
 }
 
 /**
- * @param {string} url
+ * The breadcrumb trail omits the category the page itself is showing, which the
+ * `h1` carries, so the two together reproduce the full path.
+ *
+ * @param {Document} document
  */
-function getItemIdFromUrl(url) {
-  return url.match(/p\/(\d+)(#\/)?$/)?.[1];
-}
-
-function variantsUrls({ url, document, processedIds }) {
-  const crawledItemId = getItemIdFromUrl(url);
-  return document
-    .querySelectorAll(
-      `.selectboxes .selectbox li:not([class*="disabled"]) a[wt_name*="size_variant"],
-    .selectboxes .selectbox li[data-ui-name="ads.variants.color.enabled"] a[wt_name*="color_variant"]`
-    )
-    .map(a => {
-      const productUrl = a.href;
-      if (!productUrl) {
-        return;
-      }
-      const itemId = getItemIdFromUrl(productUrl);
-      if (crawledItemId === itemId || processedIds.has(itemId)) {
-        return;
-      }
-      processedIds.add(itemId);
-      return productUrl;
-    })
-    .filter(Boolean);
-}
-
-async function enqueueVariants({ enqueueLinks, request }, { document, processedIds, stats }) {
-  const productLinkList = variantsUrls({
-    url: request.url,
-    document,
-    processedIds
-  });
-  stats.add("urls", productLinkList.length);
-  await enqueueLinks({
-    urls: productLinkList,
-    userData: { label: Labels.Detail }
-  });
+function listingCategory(document) {
+  const leaf = document.querySelector("h1")?.textContent?.trim();
+  return [...document.querySelectorAll('a[class*="normal"][wt_name*="breadcrumb.level"]')]
+    .map(a => a.textContent.trim())
+    .concat(leaf ? [leaf] : [])
+    .filter(Boolean)
+    .join("/");
 }
 
 async function main() {
@@ -200,7 +175,7 @@ async function main() {
       maxPoolSize: 150
     },
     async requestHandler(context) {
-      const { request, body, enqueueLinks, crawler } = context;
+      const { request, body, crawler } = context;
       const { url } = request;
       log.info(`Processing ${request.url}`);
       const { label } = request.userData;
@@ -254,12 +229,12 @@ async function main() {
               });
               stats.add("urls", pageRequests.length);
 
-              const urls = listUrls({ request, document, processedIds });
-              stats.add("urls", urls.length);
-              await enqueueLinks({
-                urls,
-                userData: { label: Labels.Detail }
-              });
+              const products = extractProducts({ document, url, country, processedIds });
+              stats.add("totalItems", products.length);
+              for (const product of products) {
+                stats.inc("items");
+                await Dataset.pushData(product);
+              }
               return;
             }
 
@@ -278,28 +253,9 @@ async function main() {
         case Labels.List:
           {
             const { document } = parseHTML(body.toString());
-            const urls = listUrls({ request, document, processedIds });
-            stats.add("urls", urls.length);
-            await enqueueLinks({
-              urls,
-              userData: { label: Labels.Detail }
-            });
-          }
-          break;
-        case Labels.Detail:
-          {
-            const { document } = parseHTML(body.toString());
-            stats.inc("totalItems");
-            await enqueueVariants(context, {
-              document,
-              processedIds,
-              stats
-            });
-            const product = extractProduct({
-              url: request.url,
-              document
-            });
-            if (product) {
+            const products = extractProducts({ document, url, country, processedIds });
+            stats.add("totalItems", products.length);
+            for (const product of products) {
               stats.inc("items");
               await Dataset.pushData(product);
             }


### PR DESCRIPTION
Follow-up to #3594 and #3604, from Zuzka asking why the obi run takes so long.

## Change

Read products from the category listing instead of fetching a page per product. That removes about 121000 of roughly 126000 requests.

Three things made it possible:

- The price is not in the tile text. OBI puts it in a `data-csscontent` attribute and renders it through CSS, which is why it does not look like it is there.
- Discounted tiles use a separate block, `strike-price-*`, carrying both the current price and the price before the cut, so discounts survive.
- Category comes from the listing breadcrumb plus the `h1`. The trail omits the category the page itself shows, and together they reproduce the exact path the detail page produced.

Sitemap discovery and pagination are unchanged. The `Detail` phase, `listUrls`, `variantsUrls` and `enqueueVariants` are gone.

## Measured

Platform, 8 GB, through the proxy:

| | before | after |
|---|---|---|
| outcome | never finished | **SUCCEEDED in 20.2 min** |
| products | 13849 after 60 min, ~4.4 h projected | **93625** |
| requests | ~126000 | 9123 |
| failed | | 0 |

All 93625 rows carry `itemId`, `itemName`, `itemUrl`, `currentPrice`, `currency`, `category` and `img`, with none missing on any field. 43 discounted, every one with `originalPrice` above `currentPrice`. Prices 2.99 to 589990 CZK, none non-positive.

Eleven products sampled evenly across the whole dataset, not the first eleven, matched their detail page exactly on both id and price. Category output matches the old format exactly, e.g. `Bydlení/Domácnost/Praní a sušení/Sušáky na prádlo`.

## The trade, please read before merging

Dropping the detail phase also drops variant discovery, which walked the size and colour selectors on each product page.

**42 of the 13849 products the old run had found are no longer reached.** I checked twelve of them and all twelve are still live; every one is a colour or size variant. Scaled to the full catalogue that is roughly 284 products, about 0.3%.

So this is 4.4 h to 20 min at the cost of about 0.3% of products, all variants. Worth a second opinion given the project is a discount watchdog, though the old code never completed a run either, so in practice it was delivering well under 93625.

If that 0.3% matters, the follow-up is a sitemap difference pass: the product sitemaps list 120983 products and listings reach 93625, so fetching the difference as detail pages would give fuller coverage than today at maybe 80 minutes. Happy to open that separately rather than bundle it here.

## Also worth knowing

Memory. Peak usage on the old code was 2117 MB against the 2048 MB the actor was set to, so it ran at its ceiling. This version peaks at 1559 MB.
